### PR TITLE
Fixed libobs case in FindLibObs.cmake

### DIFF
--- a/external/FindLibObs.cmake
+++ b/external/FindLibObs.cmake
@@ -86,7 +86,7 @@ if(MSVC)
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Libobs DEFAULT_MSG LIBOBS_LIB LIBOBS_INCLUDE_DIR)
+find_package_handle_standard_args(LibObs DEFAULT_MSG LIBOBS_LIB LIBOBS_INCLUDE_DIR)
 mark_as_advanced(LIBOBS_INCLUDE_DIR LIBOBS_LIB)
 
 if(LIBOBS_FOUND)


### PR DESCRIPTION
Avoids this warning in cmake .. on fedora33:

CMake Warning (dev) at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:426 (message):
  The package name passed to `find_package_handle_standard_args` (Libobs)
  does not match the name of the calling package (LibObs).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
