### PR TITLE
Feature - Process Mask every X frames of video

### DIFF
--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -52,6 +52,11 @@ struct background_removal_filter {
 	// Use the media-io converter to both scale and convert the colorspace
 	video_scaler_t* scalerToBGR;
 	video_scaler_t* scalerFromBGR;
+	
+	cv::Mat backgroundMask;
+	int maskEveryXFrames = 1;
+	int maskEveryXFramesCount = 0;
+	
 
 #if _WIN32
 	const wchar_t* modelFilepath = nullptr;
@@ -59,6 +64,7 @@ struct background_removal_filter {
 	const char* modelFilepath = nullptr;
 #endif
 };
+
 
 static const char *filter_getname(void *unused)
 {
@@ -139,12 +145,21 @@ static obs_properties_t *filter_properties(void *data)
 		"model_select",
 		obs_module_text("Segmentation model"),
 		OBS_COMBO_TYPE_LIST,
-		OBS_COMBO_FORMAT_STRING
-	);
+		OBS_COMBO_FORMAT_STRING);
+		
 	obs_property_list_add_string(p_model_select, obs_module_text("SINet"), MODEL_SINET);
 	obs_property_list_add_string(p_model_select, obs_module_text("MODNet"), MODEL_MODNET);
 	obs_property_list_add_string(p_model_select, obs_module_text("MediaPipe"), MODEL_MEDIAPIPE);
 	obs_property_list_add_string(p_model_select, obs_module_text("Selfie Segmentation"), MODEL_SELFIE);
+		
+	obs_property_t *p_mask_every_x_frames = obs_properties_add_int(
+		props,
+		"mask_every_x_frames",
+		obs_module_text("Process the Mask every X frames of video"),
+		0,
+		300,
+		1);
+	
 
 #ifndef _WIN32
     obs_property_set_enabled(p_use_gpu, false);
@@ -162,6 +177,7 @@ static void filter_defaults(obs_data_t *settings) {
 	obs_data_set_default_int(settings, "replaceColor", 0x000000);
 	obs_data_set_default_bool(settings, "useGPU", false);
 	obs_data_set_default_string(settings, "model_select", MODEL_MEDIAPIPE);
+	obs_data_set_default_int(settings, "mask_every_x_frames", 1);
 }
 
 static void createOrtSession(struct background_removal_filter *tf) {
@@ -269,9 +285,12 @@ static void filter_update(void *data, obs_data_t *settings)
 	tf->backgroundColor.val[1] = (double)((color >> 8) & 0x0000ff);
 	tf->backgroundColor.val[2] = (double)(color & 0x0000ff);
 
-	tf->contourFilter = (float)obs_data_get_double(settings, "contour_filter");
-	tf->smoothContour = (float)obs_data_get_double(settings, "smooth_contour");
-	tf->feather       = (float)obs_data_get_double(settings, "feather");
+	tf->contourFilter         = (float)obs_data_get_double(settings, "contour_filter");
+	tf->smoothContour         = (float)obs_data_get_double(settings, "smooth_contour");
+	tf->feather               = (float)obs_data_get_double(settings, "feather");
+	tf->maskEveryXFrames      = (int)obs_data_get_int(settings, "mask_every_x_frames");
+	tf->maskEveryXFramesCount = (int)(0);
+
 
 	const bool newUseGpu = (bool)obs_data_get_bool(settings, "useGPU");
 	const std::string newModel = obs_data_get_string(settings, "model_select");
@@ -376,150 +395,183 @@ static void convertBGRToFrame(
 static struct obs_source_frame * filter_render(void *data, struct obs_source_frame *frame)
 {
 	struct background_removal_filter *tf = reinterpret_cast<background_removal_filter *>(data);
-
+	
 	// Convert to BGR
 	cv::Mat imageBGR = convertFrameToBGR(frame, tf);
+	
+	cv::Mat backgroundMask;
+	tf->maskEveryXFramesCount = ++(tf->maskEveryXFramesCount) % tf->maskEveryXFrames;
+	if(tf->maskEveryXFramesCount != 0) {
+		// We are skipping processing of the mask for this frame.
+		// Get the background mask previously generated.
+		tf->backgroundMask.copyTo(backgroundMask);
 
-	try {
-
-		// To RGB
-		cv::Mat imageRGB;
-		cv::cvtColor(imageBGR, imageRGB, cv::COLOR_BGR2RGB);
-
-		// Resize to network input size
-		uint32_t inputWidth, inputHeight;
-		if (tf->modelSelection == MODEL_SINET || tf->modelSelection == MODEL_MODNET) {
-			// BCHW
-			inputWidth  = (int)tf->inputDims[3];
-			inputHeight = (int)tf->inputDims[2];
-		} else {
-			// BHWC
-			inputWidth  = (int)tf->inputDims[2];
-			inputHeight = (int)tf->inputDims[1];
-		}
-
-		cv::Mat resizedImageRGB;
-		cv::resize(imageRGB, resizedImageRGB, cv::Size(inputWidth, inputHeight));
-
-		// Prepare input to nework
-		cv::Mat resizedImage, preprocessedImage;
-		resizedImageRGB.convertTo(resizedImage, CV_32F);
-
-		if (tf->modelSelection == MODEL_SINET) {
-			cv::subtract(resizedImage, cv::Scalar(102.890434, 111.25247, 126.91212), resizedImage);
-			cv::multiply(resizedImage, cv::Scalar(1.0 / 62.93292,  1.0 / 62.82138, 1.0 / 66.355705) / 255.0, resizedImage);
-		} else if (tf->modelSelection == MODEL_MODNET) {
-			cv::subtract(resizedImage, cv::Scalar::all(127.5), resizedImage);
-			resizedImage = resizedImage / 127.5;
-		} else {
-			preprocessedImage = resizedImage / 255.0;
-		}
-
-		if (tf->modelSelection == MODEL_SINET || tf->modelSelection == MODEL_MODNET) {
-			hwc_to_chw(resizedImage, preprocessedImage);
-			tf->inputTensorValues.assign(
-				preprocessedImage.begin<float>(),
-				preprocessedImage.end<float>()
-			);
-		} else {
-			preprocessedImage.copyTo(cv::Mat(inputHeight, inputWidth, CV_32FC3, &(tf->inputTensorValues[0])));
-		}
-
-		// Run network inference
-		tf->session->Run(
-			Ort::RunOptions{nullptr},
-			tf->inputNames.data(), &(tf->inputTensor), 1,
-			tf->outputNames.data(), &(tf->outputTensor), 1);
-
-		uint32_t outputWidth, outputHeight;
-		int64_t outputChannels;
-		if (tf->modelSelection == MODEL_SINET || tf->modelSelection == MODEL_MODNET) {
-			// BCHW
-			outputWidth = (int)tf->outputDims.at(3);
-			outputHeight = (int)tf->outputDims.at(2);
-			outputChannels = CV_32FC1;
-		} else {
-			// BHWC
-			outputWidth = (int)tf->outputDims.at(2);
-			outputHeight = (int)tf->outputDims.at(1);
-			outputChannels = (tf->modelSelection == MODEL_MEDIAPIPE) ? CV_32FC2 : CV_32FC1;
-		}
-
-		// Map network output mask to cv::Mat
-		cv::Mat outputImage(outputHeight, outputWidth, outputChannels, &(tf->outputTensorValues[0]));
-
-		if (tf->modelSelection == MODEL_MEDIAPIPE) {
-			// take 1st channel
-			std::vector<cv::Mat> outputImageSplit;
-			cv::split(outputImage, outputImageSplit);
-
-			// "Softmax"
-			cv::Mat outputA, outputB;
-			cv::exp(outputImageSplit[0], outputA);
-			cv::exp(outputImageSplit[1], outputB);
-			outputImage = outputA / (outputA + outputB);
-
-			cv::normalize(outputImage, outputImage, 1.0, 0.0, cv::NORM_MINMAX);
-		}
-
-		if (tf->modelSelection == MODEL_SELFIE) {
-			cv::normalize(outputImage, outputImage, 1.0, 0.0, cv::NORM_MINMAX);
-		}
-
-		cv::Mat backgroundMask;
-		if (tf->modelSelection == MODEL_SINET || tf->modelSelection == MODEL_MEDIAPIPE) {
-			backgroundMask = outputImage > tf->threshold;
-		} else {
-			backgroundMask = outputImage < tf->threshold;
-		}
-
-		// Contour processing
-		if (tf->contourFilter > 0.0 && tf->contourFilter < 1.0) {
-			std::vector<std::vector<cv::Point> > contours;
-			findContours(backgroundMask, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
-			std::vector<std::vector<cv::Point> > filteredContours;
-			const int64_t contourSizeThreshold = (int64_t)(backgroundMask.total() * tf->contourFilter);
-			for (auto& contour : contours) {
-				if (cv::contourArea(contour) > contourSizeThreshold) {
-					filteredContours.push_back(contour);
-				}
+	}
+	else {
+		// We are processing the mask.
+		try {
+	
+			// To RGB
+			cv::Mat imageRGB;
+			cv::cvtColor(imageBGR, imageRGB, cv::COLOR_BGR2RGB);
+	
+			// Resize to network input size
+			uint32_t inputWidth, inputHeight;
+			if (tf->modelSelection == MODEL_SINET || tf->modelSelection == MODEL_MODNET) {
+				// BCHW
+				inputWidth  = (int)tf->inputDims[3];
+				inputHeight = (int)tf->inputDims[2];
+			} else {
+				// BHWC
+				inputWidth  = (int)tf->inputDims[2];
+				inputHeight = (int)tf->inputDims[1];
 			}
-			backgroundMask.setTo(0);
-			drawContours(backgroundMask, filteredContours, -1, cv::Scalar(255), -1);
+	
+			cv::Mat resizedImageRGB;
+			cv::resize(imageRGB, resizedImageRGB, cv::Size(inputWidth, inputHeight));
+	
+			// Prepare input to nework
+			cv::Mat resizedImage, preprocessedImage;
+			resizedImageRGB.convertTo(resizedImage, CV_32F);
+	
+			if (tf->modelSelection == MODEL_SINET) {
+				cv::subtract(resizedImage, cv::Scalar(102.890434, 111.25247, 126.91212), resizedImage);
+				cv::multiply(resizedImage, cv::Scalar(1.0 / 62.93292,  1.0 / 62.82138, 1.0 / 66.355705) / 255.0, resizedImage);
+			} else if (tf->modelSelection == MODEL_MODNET) {
+				cv::subtract(resizedImage, cv::Scalar::all(127.5), resizedImage);
+				resizedImage = resizedImage / 127.5;
+			} else {
+				preprocessedImage = resizedImage / 255.0;
+			}
+	
+			if (tf->modelSelection == MODEL_SINET || tf->modelSelection == MODEL_MODNET) {
+				hwc_to_chw(resizedImage, preprocessedImage);
+				tf->inputTensorValues.assign(
+					preprocessedImage.begin<float>(),
+					preprocessedImage.end<float>()
+				);
+			} else {
+				preprocessedImage.copyTo(cv::Mat(inputHeight, inputWidth, CV_32FC3, &(tf->inputTensorValues[0])));
+			}
+	
+			// Run network inference
+			tf->session->Run(
+				Ort::RunOptions{nullptr},
+				tf->inputNames.data(), &(tf->inputTensor), 1,
+				tf->outputNames.data(), &(tf->outputTensor), 1);
+	
+			uint32_t outputWidth, outputHeight;
+			int32_t outputChannels;
+			if (tf->modelSelection == MODEL_SINET || tf->modelSelection == MODEL_MODNET) {
+				// BCHW
+				outputWidth = (int)tf->outputDims.at(3);
+				outputHeight = (int)tf->outputDims.at(2);
+				outputChannels = CV_32FC1;
+			} else {
+				// BHWC
+				outputWidth = (int)tf->outputDims.at(2);
+				outputHeight = (int)tf->outputDims.at(1);
+				outputChannels = (tf->modelSelection == MODEL_MEDIAPIPE) ? CV_32FC2 : CV_32FC1;
+			}
+	
+			// Map network output mask to cv::Mat
+			cv::Mat outputImage(outputHeight, outputWidth, outputChannels, &(tf->outputTensorValues[0]));
+	
+			if (tf->modelSelection == MODEL_MEDIAPIPE) {
+				// take 1st channel
+				std::vector<cv::Mat> outputImageSplit;
+				cv::split(outputImage, outputImageSplit);
+	
+				// "Softmax"
+				cv::Mat outputA, outputB;
+				cv::exp(outputImageSplit[0], outputA);
+				cv::exp(outputImageSplit[1], outputB);
+				outputImage = outputA / (outputA + outputB);
+	
+				cv::normalize(outputImage, outputImage, 1.0, 0.0, cv::NORM_MINMAX);
+			}
+	
+			if (tf->modelSelection == MODEL_SELFIE) {
+				cv::normalize(outputImage, outputImage, 1.0, 0.0, cv::NORM_MINMAX);
+			}
+	
+			//cv::Mat backgroundMask;
+			if (tf->modelSelection == MODEL_SINET || tf->modelSelection == MODEL_MEDIAPIPE) {
+				backgroundMask = outputImage > tf->threshold;
+			} else {
+				backgroundMask = outputImage < tf->threshold;
+			}
+	
+			// Contour processing
+			if (tf->contourFilter > 0.0 && tf->contourFilter < 1.0) {
+				std::vector<std::vector<cv::Point> > contours;
+				findContours(backgroundMask, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
+				std::vector<std::vector<cv::Point> > filteredContours;
+				const int64_t contourSizeThreshold = (int64_t)(backgroundMask.total() * tf->contourFilter);
+				for (auto& contour : contours) {
+					if (cv::contourArea(contour) > contourSizeThreshold) {
+						filteredContours.push_back(contour);
+					}
+				}
+				backgroundMask.setTo(0);
+				drawContours(backgroundMask, filteredContours, -1, cv::Scalar(255), -1);
+			}
+	
+			// Resize the size of the mask back to the size of the original input.
+			cv::resize(backgroundMask, backgroundMask, imageBGR.size());
+	
+			// Smooth mask with a fast filter (box).
+			if (tf->smoothContour > 0.0) {
+				int k_size = (int)(100 * tf->smoothContour);
+				cv::boxFilter(backgroundMask, backgroundMask, backgroundMask.depth(), cv::Size(k_size, k_size));
+				backgroundMask = backgroundMask > 128;
+			}
+	
+			
+			// Now that the mask is completed, save it off so it can be used on a later frame 
+			// if we've chosen to only process the mask every X frames.
+			backgroundMask.copyTo(tf->backgroundMask);
+
+		}	
+		catch(const std::exception& e) {
+			blog(LOG_ERROR, "%s", e.what());
 		}
-
-		// Mask the input
-		cv::resize(backgroundMask, backgroundMask, imageBGR.size());
-
-		// Smooth mask with a fast filter (box)
-		if (tf->smoothContour > 0.0) {
-			int k_size = (int)(100 * tf->smoothContour);
-			cv::boxFilter(backgroundMask, backgroundMask, backgroundMask.depth(), cv::Size(k_size, k_size));
-			backgroundMask = backgroundMask > 128;
-		}
-
-		if (tf->feather > 0.0) {
-			// Feather mask
-			int k_size = (int)(40 * tf->feather);
+	}
+	
+	// Apply the mask back to the main image.
+	try {
+		if (tf->feather > 0.0) {	
+			// If we're going to feather/alpha blend, we need to do some processing that 
+			// will combine the blended "foreground" and "masked background" images onto the main image.
 			cv::Mat maskFloat;
+			int k_size = (int)(40 * tf->feather);
+			
+			// Convert Mat to float and Normalize the alpha mask to keep intensity between 0 and 1.
 			backgroundMask.convertTo(maskFloat, CV_32FC1, 1.0 / 255.0);
+			//Feather the normalized mask.
 			cv::boxFilter(maskFloat, maskFloat, maskFloat.depth(), cv::Size(k_size, k_size));
-
+			
 			// Alpha blend
 			cv::Mat maskFloat3c;
 			cv::cvtColor(maskFloat, maskFloat3c, cv::COLOR_GRAY2BGR);
 			cv::Mat tmpImage, tmpBackground;
+			// Mutiply the unmasked foreground area of the image with ( 1 - alpha matte).
 			cv::multiply(imageBGR, cv::Scalar(1, 1, 1) - maskFloat3c, tmpImage, 1.0, CV_32FC3);
+			// Multiply the masked background area (with the background color applied) with the alpha matte.
 			cv::multiply(cv::Mat(imageBGR.size(), CV_32FC3, tf->backgroundColor), maskFloat3c, tmpBackground);
+			// Add the foreground and background images together, rescale back to an 8bit integer image
+			// , and apply onto the main image.
 			cv::Mat(tmpImage + tmpBackground).convertTo(imageBGR, CV_8UC3);
 		} else {
+			// If we're not feathering/alpha blending, we can
+			// apply the mask as-is back onto the main image.
 			imageBGR.setTo(tf->backgroundColor, backgroundMask);
 		}
 	}
 	catch(const std::exception& e) {
 		blog(LOG_ERROR, "%s", e.what());
 	}
-	// Put masked image back on frame
+	// Put masked image back on frame,
 	convertBGRToFrame(imageBGR, frame, tf);
 	return frame;
 }


### PR DESCRIPTION
Added the feature to Process the Mask every X frames of video.  This can greatly decrease the CPU usage of the plugin making it usable on lower-spec'd systems, and people may even prefer the visual effect of processing the mask less frequently as it can make the contours of the mask less "jittery".