### PR TITLE
fix macOS /Library installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,12 @@ $ cpack
 ```
 
 #### Install
-Unpack the package to the plugins directory of the system's Library folder (which is Apple's preffered way)
-```
-$ unzip -o obs-backgroundremoval-macosx.zip -d "/Library/Application Support/obs-studio/plugins"
+Unpack the package to the plugins directory of the system's Library folder (which is Apple's preferred way but requires admin privileges)
+
+```sh
+sudo mkdir -p "/Library/Application Support/obs-studio/plugins/obs-backgroundremoval"
+sudo unzip -j obs-backgroundremoval-macosx.zip "Plugins/obs-backgroundremoval.so" -d "/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/bin"
+sudo unzip -j obs-backgroundremoval-macosx.zip "Resources/data/obs-plugins/obs-backgroundremoval/*" -d "/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/data"
 ```
 
 or directly to your OBS install directory, e.g.
@@ -74,7 +77,7 @@ or directly to your OBS install directory, e.g.
 $ unzip -o obs-backgroundremoval-macosx.zip -d /Applications/OBS.app/Contents/
 ```
 
-The first is recommended as it preserves the plugins over the parallel installation of OBS versions (i.e. running the latest productive version and a release candidate) whereas the latter will also remove the plugin if you decide to delete the OBS application.
+The first is recommended as it preserves the plugins over the parallel installation of OBS versions (i.e. running the latest productive version and a release candidate), or operations like `brew upgrade obs`, whereas the latter will also remove the plugin if you decide to delete the OBS application.
 
 ### Linux
 


### PR DESCRIPTION
The current preferred installation method for macOS from https://github.com/royshil/obs-backgroundremoval/pull/15 is `unzip -o obs-backgroundremoval-macosx.zip -d "/Library/Application Support/obs-studio/plugins"`. This results in files that do not seem to match the expected file hierarchy.

There are instances where faulty macOS install instructions resulted in people trying to fix it manually, to their confusion when it did not work: https://github.com/royshil/obs-backgroundremoval/issues/51

Working file structure (obs-backgroundremoval v0.4.0, OBS v27.1.3):
```console
sh-3.2# find "/Library/Application Support/obs-studio/plugins"
/Library/Application Support/obs-studio/plugins
/Library/Application Support/obs-studio/plugins/obs-backgroundremoval
/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/bin
/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/bin/obs-backgroundremoval.so
/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/data
/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/data/locale
/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/data/locale/en-US.ini
/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/data/modnet_simple.onnx
/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/data/mediapipe.onnx
/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/data/SINet_Softmax_simple.onnx
/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/data/rvm_mobilenetv3_fp32.onnx
/Library/Application Support/obs-studio/plugins/obs-backgroundremoval/data/selfie_segmentation.onnx
```