### PR TITLE
Add a flatpak build workflow to this plugin

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -13,8 +13,9 @@ jobs:
   build:
     name: Build flatpak
     runs-on: [ubuntu-latest]
-    env:
-      FLATPAK_BUILD_PATH: flatpak_app/files/share
+    strategy:
+      matrix:
+        arch: [x86_64]
     container:
       image: bilelmoussaoui/flatpak-github-actions:kde-6.4
       options: --privileged
@@ -33,13 +34,21 @@ jobs:
       - name: Build Flatpak Manifest
         uses: flatpak/flatpak-github-actions/flatpak-builder@v5
         with:
-          bundle: obs-studio-${{ steps.setup.outputs.commitHash }}.flatpak
+          arch: ${{ matrix.arch }}
+          bundle: obs-studio-plugin-background-removal-${{ steps.setup.outputs.commitHash }}.flatpak
+          build-bundle: false
           manifest-path: ci/flatpak/com.obsproject.Studio.Plugin.backgroundremoval.yaml
           cache-key: flatpak-builder-${{ hashFiles('ci/flatpak/com.obsproject.Studio.Plugin.backgroundremoval.yaml') }}
-          branch: master
+          branch: stable
 
-      - name: Validate AppStream
+      # /__w/obs-backgroundremoval/obs-backgroundremoval/
+      - name: Build Bundle
         shell: bash
-        working-directory: ${{ env.FLATPAK_BUILD_PATH }}
         run: |
-          appstream-util validate appdata/com.obsproject.Studio.Plugin.backgroundremoval.appdata.xml
+          flatpak build-bundle --runtime repo com.obs.Studio.Plugin.backgroundremoval-${{ steps.setup.outputs.commitHash }}.flatpak com.obsproject.Studio.Plugin.backgroundremoval stable
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: com.obs.Studio.Plugin.backgroundremoval-${{ steps.setup.outputs.commitHash }}.flatpak
+          path: com.obs.Studio.Plugin.backgroundremoval-${{ steps.setup.outputs.commitHash }}.flatpak

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,45 @@
+# This is a basic workflow that is manually triggered
+
+name: Build flatpak
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch: {}
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "greet"
+  build:
+    name: Build flatpak
+    runs-on: [ubuntu-latest]
+    env:
+      FLATPAK_BUILD_PATH: flatpak_app/files/share
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:kde-6.4
+      options: --privileged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: 'Setup build environment'
+        id: setup
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          echo "commitHash=$(git rev-parse --short=9 HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build Flatpak Manifest
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v5
+        with:
+          bundle: obs-studio-${{ steps.setup.outputs.commitHash }}.flatpak
+          manifest-path: ci/flatpak/com.obsproject.Studio.Plugin.backgroundremoval.yaml
+          cache-key: flatpak-builder-${{ hashFiles('ci/flatpak/com.obsproject.Studio.Plugin.backgroundremoval.yaml') }}
+          branch: master
+
+      - name: Validate AppStream
+        shell: bash
+        working-directory: ${{ env.FLATPAK_BUILD_PATH }}
+        run: |
+          appstream-util validate appdata/com.obsproject.Studio.Plugin.backgroundremoval.appdata.xml

--- a/ci/flatpak/com.obsproject.Studio.Plugin.backgroundremoval.metainfo.xml
+++ b/ci/flatpak/com.obsproject.Studio.Plugin.backgroundremoval.metainfo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.obsproject.Studio.Plugin.backgroundremoval</id>
+  <extends>com.obsproject.Studio</extends>
+  <name>obs-backgroundremoval Plugin</name>
+  <summary> An OBS plugin for removing background in portrait images (video), making it easy to replace the background when screen recording.</summary>
+  <url type="homepage">https://github.com/royshil/obs-backgroundremoval</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+</component>

--- a/ci/flatpak/com.obsproject.Studio.Plugin.backgroundremoval.yaml
+++ b/ci/flatpak/com.obsproject.Studio.Plugin.backgroundremoval.yaml
@@ -1,0 +1,60 @@
+# build into folder "build-dir":
+# $ flatpak-builder build-dir com.obsproject.Studio.Plugin.backgroundremoval.yaml --force-clean
+#
+# install:
+# $ flatpak-builder --user --install --force-clean build-dir com.obsproject.Studio.Plugin.backgroundremoval.yaml
+id: com.obsproject.Studio.Plugin.backgroundremoval
+runtime: com.obsproject.Studio
+runtime-version: stable
+sdk: org.kde.Sdk/x86_64/6.4
+build-extension: true
+separate-locales: false
+appstream-compose: false
+build-options:
+  prefix: /app/plugins/backgroundremoval
+modules:
+  # onnxruntime has a bash+python+cmake build script - just download/use pre-compiled library
+  # https://onnxruntime.ai/docs/build/inferencing.html
+  - name: onnxruntime
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://github.com/microsoft/onnxruntime/releases/download/v1.11.1/onnxruntime-linux-x64-1.11.1.tgz
+        sha256: ddc03b5ae325c675ff76a6f18786ce7d310be6eb6f320087f7a0e9228115f24d
+    build-commands:
+      - mkdir -p ${FLATPAK_DEST}/include ${FLATPAK_DEST}/lib
+      - mv include/* ${FLATPAK_DEST}/include
+      - mv lib/* ${FLATPAK_DEST}/lib
+  # https://docs.opencv.org/4.x/db/d05/tutorial_config_reference.html
+  - name: opencv
+    buildsystem: cmake
+    config-opts:
+      - "-DCMAKE_BUILD_TYPE=Release"
+      - "-DBUILD_LIST=imgproc"
+    cleanup:
+    - "/bin"
+    builddir: true
+    sources:
+      - type: archive
+        url: https://github.com/opencv/opencv/archive/refs/tags/4.5.5.tar.gz
+        sha256: a1cfdcf6619387ca9e232687504da996aaa9f7b5689986b8331ec02cb61d28ad
+  - name: obs-backgroundremoval
+    buildsystem: cmake
+    builddir: true
+    config-opts:
+      - -DLIBOBS_INCLUDE_DIR=/app/include/obs
+      - -DOnnxruntime_INCLUDE_DIR=/app/plugins/backgroundremoval/include
+      - -DOnnxruntime_LIBRARIES=/app/plugins/backgroundremoval/lib/libonnxruntime.so
+    sources:
+      - type: git
+        url: https://github.com/royshil/obs-backgroundremoval.git
+        tag: v0.4.0
+        commit: 4f0348a15103cd4e516d94b629851208280cd4d4
+  - name: appdata
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+    sources:
+      - type: file
+        path: com.obsproject.Studio.Plugin.backgroundremoval.metainfo.xml

--- a/ci/flatpak/flathub.json
+++ b/ci/flatpak/flathub.json
@@ -1,0 +1,4 @@
+{
+    "skip-icons-check": true,
+    "only-arches": ["x86_64"]
+}


### PR DESCRIPTION
I used the files from @tam7t from #67 and added them to a github workflow.

I didn't add any triggers, because right now the workflow will upload the `flatpak` build as an artifact to each run, so I didn't want to clutter your repository with the big artifacts.

But this way it should be reasonably simply to trigger a build every once in a while, so flatpak users can download a plugin they can just install and use.

Or - if nothing else - maybe you can just use this as starting point to create your own better workflow.

Only weird idiosyncrasy I found is that I couldn't use the flatpak bundle feature of the action, as the plugin is a `runtime` not an `app` - that's why I added a step that actually builds the bundle. 