### PR TITLE
Enable -Werror and /WX

### DIFF
--- a/cmake/ObsPluginHelpers.cmake
+++ b/cmake/ObsPluginHelpers.cmake
@@ -174,7 +174,7 @@ if(OS_POSIX)
   target_compile_options(
     ${CMAKE_PROJECT_NAME}
     PRIVATE
-      # -Werror
+      -Werror
       -Wextra
       -Wvla
       -Wformat
@@ -550,7 +550,7 @@ else()
         ${CMAKE_PROJECT_NAME}
         PRIVATE /MP
                 /W3
-                # /WX
+                /WX
                 /wd4201
                 "$<$<CONFIG:RELWITHDEBINFO>:/Ob2>"
                 "$<$<CONFIG:DEBUG>:/DDEBUG=1;/D_DEBUG=1>"

--- a/src/Model.h
+++ b/src/Model.h
@@ -391,8 +391,8 @@ class ModelRVM : public ModelBCHW {
     for (size_t i = 1; i < 5; i++) {
       inputDims[i][0] = 1;
       inputDims[i][1] = (i == 1) ? 16 : (i == 2) ? 20 : (i == 3) ? 40 : 64;
-      inputDims[i][2] = 192 / std::pow(2, i);
-      inputDims[i][3] = 192 / std::pow(2, i);
+      inputDims[i][2] = 192 / (2 << i);
+      inputDims[i][3] = 192 / (2 << i);
     }
 
     outputDims[0][0] = 1;
@@ -400,8 +400,8 @@ class ModelRVM : public ModelBCHW {
     outputDims[0][3] = 192;
     for (size_t i = 1; i < 5; i++) {
       outputDims[i][0] = 1;
-      outputDims[i][2] = 192 / std::pow(2, i);
-      outputDims[i][3] = 192 / std::pow(2, i);
+      outputDims[i][2] = 192 / (2 << i);
+      outputDims[i][3] = 192 / (2 << i);
     }
     return true;
   }

--- a/src/Model.h
+++ b/src/Model.h
@@ -391,8 +391,8 @@ class ModelRVM : public ModelBCHW {
     for (size_t i = 1; i < 5; i++) {
       inputDims[i][0] = 1;
       inputDims[i][1] = (i == 1) ? 16 : (i == 2) ? 20 : (i == 3) ? 40 : 64;
-      inputDims[i][2] = 192 / (2 << i);
-      inputDims[i][3] = 192 / (2 << i);
+      inputDims[i][2] = 192 / (2 << (i - 1));
+      inputDims[i][3] = 192 / (2 << (i - 1));
     }
 
     outputDims[0][0] = 1;
@@ -400,8 +400,8 @@ class ModelRVM : public ModelBCHW {
     outputDims[0][3] = 192;
     for (size_t i = 1; i < 5; i++) {
       outputDims[i][0] = 1;
-      outputDims[i][2] = 192 / (2 << i);
-      outputDims[i][3] = 192 / (2 << i);
+      outputDims[i][2] = 192 / (2 << (i - 1));
+      outputDims[i][3] = 192 / (2 << (i - 1));
     }
     return true;
   }

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -433,7 +433,8 @@ static struct obs_source_frame *filter_render(void *data, struct obs_source_fram
 
   cv::Mat backgroundMask(imageBGR.size(), CV_8UC1, cv::Scalar(255));
 
-  tf->maskEveryXFramesCount = ++(tf->maskEveryXFramesCount) % tf->maskEveryXFrames;
+  tf->maskEveryXFramesCount++;
+  tf->maskEveryXFramesCount %= tf->maskEveryXFrames;
   if (tf->maskEveryXFramesCount != 0 && !tf->backgroundMask.empty()) {
     // We are skipping processing of the mask for this frame.
     // Get the background mask previously generated.


### PR DESCRIPTION
Enables -Werror in linux and mac and /WX in Windows.

The increment in assignment may conclude in undefined behavior.
std::pow is double so they turned into integer operations.