### PR TITLE
Fix Build error

### DIFF
--- a/cmake/BuildMyOpenCV.cmake
+++ b/cmake/BuildMyOpenCV.cmake
@@ -33,8 +33,8 @@ endif()
 
 ExternalProject_Add(
   OpenCV_Build
-  URL https://github.com/opencv/opencv/archive/refs/tags/4.7.0.tar.gz DOWNLOAD_EXTRACT_TIMESTAMP
-      true
+  DOWNLOAD_EXTRACT_TIMESTAMP true
+  URL https://github.com/opencv/opencv/archive/refs/tags/4.7.0.tar.gz
   PATCH_COMMAND ${OpenCV_INSTALL_CCACHE}
   BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config ${OpenCV_BUILD_TYPE}
   BUILD_BYPRODUCTS


### PR DESCRIPTION
Building on Pop_os resulted in an At least one entry of URL is a path (invalid in a list) warning. This seems to be caused by a forgotten newline in this function. I'm no expert at this, so please correct me if I'm wrong, but this change got my build working again.