### PR TITLE
Remove random url from windows installer causing malware threats

### DIFF
--- a/cmake/bundle/windows/installer-Windows.iss.in
+++ b/cmake/bundle/windows/installer-Windows.iss.in
@@ -1,7 +1,7 @@
 #define MyAppName "@CMAKE_PROJECT_NAME@"
 #define MyAppVersion "@CMAKE_PROJECT_VERSION@"
 #define MyAppPublisher "@PLUGIN_AUTHOR@"
-#define MyAppURL "http://www.mywebsite.com"
+#define MyAppURL "https://github.com/royshil/obs-backgroundremoval"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.

--- a/installer/installer-Windows.iss.in
+++ b/installer/installer-Windows.iss.in
@@ -1,7 +1,7 @@
 #define MyAppName "@CMAKE_PROJECT_NAME@"
 #define MyAppVersion "@CMAKE_PROJECT_VERSION@"
 #define MyAppPublisher "@PLUGIN_AUTHOR@"
-#define MyAppURL "http://www.mywebsite.com"
+#define MyAppURL "https://github.com/royshil/obs-backgroundremoval"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.


### PR DESCRIPTION
according to https://github.com/obsproject/obs-plugintemplate/issues/70 the mywebsite.com url in the windows installer causes a malware threat. on top of being just wrong.