### PR TITLE
Abort if tf->model is null in createOrtSession

### DIFF
--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -164,6 +164,10 @@ static void filter_defaults(obs_data_t *settings)
 
 static void createOrtSession(struct background_removal_filter *tf)
 {
+  if (tf->model.get() == nullptr) {
+    blog(LOG_ERROR, "Model object is not initialized");
+    return;
+  }
 
   Ort::SessionOptions sessionOptions;
 


### PR DESCRIPTION
If a user have migrated from an older version of this plugin, old model files may have remained and tf->modelSelection is set not to be prefixed with models. This change aborts the createOrtSession if tf->model is null and it prevents the segmentation fault of executing tf->model->populateInputOutputNames() when tf->model is null.

Fixes #184.