### PR TITLE
Remove BG color, transparent by default

### DIFF
--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -486,7 +486,7 @@ static struct obs_source_frame *filter_render(void *data, struct obs_source_fram
       // bgra[0,1,2] -> bgra[0,1,2],
       // bgra[3] -> alpha[0]
       int from_to[] = {0, 0, 1, 1, 2, 2, 3, 3};
-      mixChannels(&bgra, 1, out, 2, from_to, 4);
+      mixChannels(&imageBGRA, 1, out, 2, from_to, 4);
     } else {
       // If we're not feathering/alpha blending, we can
       // apply the mask as-is back onto the main image.

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -482,11 +482,9 @@ static struct obs_source_frame *filter_render(void *data, struct obs_source_fram
 
       cv::Mat alpha;
       cv::Mat((cv::Scalar(1.0) - maskFloat) * 255.0).convertTo(alpha, CV_8UC1);
-      cv::Mat out[] = {imageBGRA, alpha};
-      // bgra[0,1,2] -> bgra[0,1,2],
-      // bgra[3] -> alpha[0]
-      int from_to[] = {0, 0, 1, 1, 2, 2, 3, 3};
-      mixChannels(&imageBGRA, 1, out, 2, from_to, 4);
+      // alpha[0] -> bgra[3]
+      int from_to[] = {0, 3};
+      mixChannels(&alpha, 1, &imageBGRA, 1, from_to, 1);
     } else {
       // If we're not feathering/alpha blending, we can
       // apply the mask as-is back onto the main image.

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -476,7 +476,7 @@ static struct obs_source_frame *filter_render(void *data, struct obs_source_fram
       // Convert Mat to float and Normalize the alpha mask to [0,1].
       cv::Mat maskFloat;
       tf->backgroundMask.convertTo(maskFloat, CV_32FC1, 1.0 / 255.0);
-      
+
       // Feather (blur) the normalized mask
       const int k_size = (int)(40 * tf->feather);
       cv::dilate(maskFloat, maskFloat, cv::Mat(), cv::Point(-1, -1), k_size / 3);
@@ -484,8 +484,8 @@ static struct obs_source_frame *filter_render(void *data, struct obs_source_fram
 
       cv::Mat alpha;
       cv::Mat((cv::Scalar(1.0) - maskFloat) * 255.0).convertTo(alpha, CV_8UC1);
-      
-      int from_to[] = {0, 3};  // alpha[0] -> bgra[3]
+
+      int from_to[] = {0, 3}; // alpha[0] -> bgra[3]
       mixChannels(&alpha, 1, &imageBGRA, 1, from_to, 1);
     } else {
       // If we're not feathering/alpha blending, we can

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -480,13 +480,13 @@ static struct obs_source_frame *filter_render(void *data, struct obs_source_fram
       const int k_size = (int)(40 * tf->feather);
       cv::boxFilter(maskFloat, maskFloat, maskFloat.depth(), cv::Size(k_size, k_size));
 
-      Mat alpha;
-      ((cv::Scalar(1.0) - maskFloat) * 255.0).convertTo(alpha, CV_8UC1);
-      Mat out[] = { imageBGRA, alpha };
-      // bgra[0,1,2] -> bgra[0,1,2], 
+      cv::Mat alpha;
+      cv::Mat((cv::Scalar(1.0) - maskFloat) * 255.0).convertTo(alpha, CV_8UC1);
+      cv::Mat out[] = {imageBGRA, alpha};
+      // bgra[0,1,2] -> bgra[0,1,2],
       // bgra[3] -> alpha[0]
-      int from_to[] = { 0,0, 1,1, 2,2, 3,3 };
-      mixChannels( &bgra, 1, out, 2, from_to, 4 );
+      int from_to[] = {0, 0, 1, 1, 2, 2, 3, 3};
+      mixChannels(&bgra, 1, out, 2, from_to, 4);
     } else {
       // If we're not feathering/alpha blending, we can
       // apply the mask as-is back onto the main image.


### PR DESCRIPTION
Removing the ability to set the background color, it will always be transparent.
This will undo the need for an additional chroma key filter.

closing #193 