### PR TITLE
Fix CMakeLists.txt for Flatpak builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25.2)
+cmake_minimum_required(VERSION 3.25.1)
 
 set(CMAKE_CXX_STANDARD 20)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
@@ -52,19 +52,18 @@ set(USE_SYSTEM_ONNXRUNTIME
 if(USE_SYSTEM_ONNXRUNTIME)
   if(OS_LINUX)
     find_package(Onnxruntime 1.14.1 REQUIRED)
-    add_library(Onnxruntime SHARED IMPORTED)
-    set_target_properties(Onnxruntime PROPERTIES IMPORTED_LOCATION ${Onnxruntime_LIBRARIES})
     set(Onnxruntime_INCLUDE_PATH
         ${Onnxruntime_INCLUDE_DIR} ${Onnxruntime_INCLUDE_DIR}/onnxruntime
         ${Onnxruntime_INCLUDE_DIR}/onnxruntime/core/session
         ${Onnxruntime_INCLUDE_DIR}/onnxruntime/core/providers/cpu)
-    set_target_properties(Onnxruntime PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-                                                 "${Onnxruntime_INCLUDE_PATH}")
+    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE "${Onnxruntime_LIBRARIES}")
+    target_include_directories(${CMAKE_PROJECT_NAME} SYSTEM PUBLIC "${Onnxruntime_INCLUDE_PATH}")
   else()
     message(FATAL_ERROR "System ONNX Runtime is only supported on Linux!")
   endif()
 else()
   include(cmake/BuildMyOnnxruntime.cmake)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Onnxruntime)
 endif()
 
 set(USE_SYSTEM_OPENCV
@@ -73,20 +72,19 @@ set(USE_SYSTEM_OPENCV
 if(USE_SYSTEM_OPENCV)
   if(OS_LINUX)
     find_package(OpenCV REQUIRED COMPONENTS core imgproc)
-    add_library(OpenCV SHARED IMPORTED)
-    set_target_properties(OpenCV PROPERTIES IMPORTED_LOCATION ${OpenCV_LIBRARIES})
-    set_target_properties(OpenCV PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${OpenCV_INCLUDE_DIRS}")
+    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE "${OpenCV_LIBRARIES}")
+    target_include_directories(${CMAKE_PROJECT_NAME} SYSTEM PUBLIC "${OpenCV_INCLUDE_DIRS}")
   else()
     message(FATAL_ERROR "System OpenCV is only supported on Linux!")
   endif()
 else()
   include(cmake/BuildMyOpenCV.cmake)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE OpenCV)
 endif()
 
 if(OS_WINDOWS)
   install(IMPORTED_RUNTIME_ARTIFACTS Onnxruntime::DirectML DESTINATION "${OBS_PLUGIN_DESTINATION}")
 endif()
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Onnxruntime OpenCV)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin|iOS")
   foreach(flags CMAKE_CXX_FLAGS CMAKE_OBJC_FLAGS CMAKE_OBJCXX_FLAGS)
     string(APPEND ${flags} " -fvisibility=hidden -fvisibility-inlines-hidden")


### PR DESCRIPTION
Flatpak has CMake 3.25.1.
cmake_minimum_required must be below 3.25.1 for Flatpak.
Building ONNX Runtime requires 3.25.2 but we use pre-built ONNX Runtime for Flatpak so that CMake 3.25.1 is valid only for Flatpak build.
The deb build still requires 3.25.2 and this is great to note on README.md or CONTRIBUTING.md.