### PR TITLE
Feathering should be done within the contour

### DIFF
--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -487,6 +487,7 @@ static struct obs_source_frame *filter_render(void *data, struct obs_source_fram
       // Convert Mat to float and Normalize the alpha mask to [0,1].
       tf->backgroundMask.convertTo(maskFloat, CV_32FC1, 1.0 / 255.0);
       // Feather (blur) the normalized mask
+      cv::dilate(maskFloat, maskFloat, cv::Mat(), cv::Point(-1, -1), k_size / 3);
       cv::boxFilter(maskFloat, maskFloat, maskFloat.depth(), cv::Size(k_size, k_size));
 
       if (tf->backgroundColor[3] == 255) {


### PR DESCRIPTION
In the current implementation, feathering the portrait will include the edge of the background and I don't think this is what people expect from the feathering feature.
<img width="553" alt="スクリーンショット 2023-03-22 4 08 30" src="https://user-images.githubusercontent.com/1067855/226715679-59136a00-8d8f-499f-a7d4-291e631d8eb1.png">

Adding erosion process before boxFilter will be what people expect.
<img width="569" alt="スクリーンショット 2023-03-22 4 10 12" src="https://user-images.githubusercontent.com/1067855/226715869-c5f5bbbd-4488-4808-b5bc-4f383112808b.png">
