### PR TITLE
Use pkgbuild and productbuild for .pkg

### DIFF
--- a/.github/scripts/.package.zsh
+++ b/.github/scripts/.package.zsh
@@ -155,6 +155,7 @@ Usage: %B${functrace[1]%:*}%b <option> [<options>]
       --distribution "${project_root}/cmake/bundle/macos/Distribution.xml" \
       --package-path "${project_root}/release" \
       "${project_root}/release/${product_name}.pkg"
+    rm "${project_root}/release/${product_name}-flat.pkg"
 
     if (( ${+CODESIGN} )) {
       read_codesign_installer

--- a/.github/scripts/.package.zsh
+++ b/.github/scripts/.package.zsh
@@ -145,13 +145,16 @@ Usage: %B${functrace[1]%:*}%b <option> [<options>]
       return 2
     }
 
-    check_packages
-
     log_info "Packaging ${product_name}..."
     pushd ${project_root}
-    packagesbuild \
-      --build-folder ${project_root}/release \
-      ${project_root}/build_${target##*-}/installer-macos.generated.pkgproj
+    pkgbuild \
+      --component "${project_root}/release/obs-backgroundremoval.plugin" \
+      --install-location "/Library/Application Support/obs-studio/plugins" \
+       "${project_root}/release/${product_name}-flat.pkg"
+    productbuild \
+      --distribution "${project_root}/cmake/bundle/macos/Distribution.xml" \
+      --package-path "${project_root}/release" \
+      "${project_root}/release/${product_name}.pkg"
 
     if (( ${+CODESIGN} )) {
       read_codesign_installer

--- a/.github/scripts/.package.zsh
+++ b/.github/scripts/.package.zsh
@@ -150,6 +150,7 @@ Usage: %B${functrace[1]%:*}%b <option> [<options>]
     pkgbuild \
       --component "${project_root}/release/obs-backgroundremoval.plugin" \
       --install-location "/Library/Application Support/obs-studio/plugins" \
+      --scripts "${project_root}/cmake/bundle/macos/scripts" \
        "${project_root}/release/${product_name}-flat.pkg"
     productbuild \
       --distribution "${project_root}/cmake/bundle/macos/Distribution.xml" \

--- a/cmake/bundle/macos/Distribution.xml
+++ b/cmake/bundle/macos/Distribution.xml
@@ -12,5 +12,5 @@
         <pkg-ref id="com.royshilkrot.obs-backgroundremoval"/>
     </choice>
     <pkg-ref id="com.royshilkrot.obs-backgroundremoval" version="1.0.0" onConclusion="none">obs-backgroundremoval-flat.pkg</pkg-ref>
-    <domains enable_currentUserHome="true"/>
+    <domains enable_anywhere="false" enable_currentUserHome="true" enable_localSystem="false"/>
 </installer-gui-script>

--- a/cmake/bundle/macos/Distribution.xml
+++ b/cmake/bundle/macos/Distribution.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="1">
+    <pkg-ref id="com.royshilkrot.obs-backgroundremoval"/>
+    <options customize="never" require-scripts="false" hostArchitectures="x86_64,arm64"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="com.royshilkrot.obs-backgroundremoval"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="com.royshilkrot.obs-backgroundremoval" visible="false">
+        <pkg-ref id="com.royshilkrot.obs-backgroundremoval"/>
+    </choice>
+    <pkg-ref id="com.royshilkrot.obs-backgroundremoval" version="1.0.0" onConclusion="none">obs-backgroundremoval-flat.pkg</pkg-ref>
+    <domains enable_currentUserHome="true"/>
+</installer-gui-script>

--- a/cmake/bundle/macos/scripts/postinstall
+++ b/cmake/bundle/macos/scripts/postinstall
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [[ "$2" = "/Library/Application Support/obs-studio/plugins" ]]
+then
+  /usr/bin/su "$USER" -c '/usr/sbin/installer -pkg "'$1'" -target CurrentUserHomeDirectory'
+fi


### PR DESCRIPTION
The pkg file created by the Packages will require users to do the following steps.

https://github.com/royshil/obs-backgroundremoval/issues/146#issuecomment-1456343517

The pkgbuild and productbuild commands are the newer way to create pkgs and AFAIK pkgs created by these commands won't require users to take the additional steps to install files under the home directory.