### PR TITLE
Adopt stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '28 23 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-message: 'This issue is stale because it has been open for 60 days with no activity.'
+          stale-pr-message: 'This issue was closed because it has been inactive for 14 days since being marked as stale.'
+          stale-issue-label: 'no-issue-activity'


### PR DESCRIPTION
Handling stale issues automatically.
We have to create no-issue-activity label for the bot to check if 14 days passed after the issue was marked as stalled.
If we adopt the stall bot, the criteria of our closing issue would be clear and the closed issue participants would be convinced.

https://github.com/marketplace/actions/close-stale-issues