### PR TITLE
Use uint8_t buffer for inter-thread communication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,9 @@ if(OS_WINDOWS)
   if(MSVC)
     target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE /W4)
   endif()
+
+  target_include_directories(${CMAKE_PROJECT_NAME} SYSTEM
+                             PRIVATE ${CMAKE_SOURCE_DIR}/../obs-studio/deps/w32-pthreads)
   # --- End of section ---
 
   # -- macOS specific build settings and tasks --

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -541,7 +541,7 @@ static void filter_video_render(void *data, gs_effect_t *_effect)
   gs_texture_t *texture = gs_texture_create(width, height, GS_BGRA, 1, textureData, 0);
   gs_effect_t *effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
   gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
-  gs_effect_set_texture(image, texture);
+  gs_effect_set_texture_srgb(image, texture);
   gs_blend_state_push();
   gs_reset_blend_state();
   while (gs_effect_loop(effect, "Draw")) {

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -476,7 +476,8 @@ void filter_video_tick(void *data, float seconds)
     blog(LOG_ERROR, "%s", e.what());
   }
 
-  if (!tf->outputData || tf->outputWidth != static_cast<uint32_t>(imageBGRA.cols) || tf->outputHeight != static_cast<uint32_t>(imageBGRA.rows)) {
+  if (!tf->outputData || tf->outputWidth != static_cast<uint32_t>(imageBGRA.cols) ||
+      tf->outputHeight != static_cast<uint32_t>(imageBGRA.rows)) {
     if (tf->outputData) {
       bfree(tf->outputData);
     }
@@ -521,7 +522,8 @@ static void filter_video_render(void *data, gs_effect_t *_effect)
   if (!gs_stagesurface_map(stagesurface, &video_data, &linesize)) {
     return;
   }
-  if (!tf->inputData || tf->inputWidth != width || tf->inputHeight != height || tf->inputLinesize != linesize) {
+  if (!tf->inputData || tf->inputWidth != width || tf->inputHeight != height ||
+      tf->inputLinesize != linesize) {
     if (tf->inputData) {
       bfree(tf->inputData);
     }

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -81,9 +81,6 @@ struct background_removal_filter {
   int maskEveryXFramesCount = 0;
   int64_t blurBackground = 0;
 
-  cv::Mat inputBGRA;
-  cv::Mat outputBGRA;
-
 #if _WIN32
   const wchar_t *modelFilepath = nullptr;
 #else


### PR DESCRIPTION
Referencing cv::Mat from two different threads may cause an OBS crash.
https://github.com/royshil/obs-backgroundremoval/issues/223

By this change, all the cv::Mat will be referenced by only a single thread and may suppress crashes on cv::Mat.clone()