### PR TITLE
Fix escaping on postinstall of Mac pkg

### DIFF
--- a/cmake/bundle/macos/scripts/postinstall
+++ b/cmake/bundle/macos/scripts/postinstall
@@ -2,5 +2,5 @@
 
 if [[ "$2" = "/Library/Application Support/obs-studio/plugins" ]]
 then
-  /usr/bin/su "$USER" -c '/usr/sbin/installer -pkg "'$1'" -target CurrentUserHomeDirectory'
+  /usr/bin/su "$USER" -c "/usr/sbin/installer -pkg $(printf %q "$1") -target CurrentUserHomeDirectory"
 fi


### PR DESCRIPTION
The installer has failed to install when the path of pkg contains any spaces such as `obs-backgroundremoval-0.5.15-macos-arm64 (1).pkg`.
This change escapes spaces properly and fixes the installation problem on Mac.