### PR TITLE
Use gs_effect_set_texture

### DIFF
--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -534,7 +534,7 @@ static void filter_video_render(void *data, gs_effect_t *_effect)
   gs_texture_t *texture = gs_texture_create(width, height, GS_BGRA, 1, textureData, 0);
   gs_effect_t *effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
   gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
-  gs_effect_set_texture_srgb(image, texture);
+  gs_effect_set_texture(image, texture);
   gs_blend_state_push();
   gs_reset_blend_state();
   while (gs_effect_loop(effect, "Draw")) {


### PR DESCRIPTION
This filter changed the color of the image. This change fixes the filter to keep the color of the image.

Fixes #218

<img width="973" alt="スクリーンショット 2023-03-30 1 49 36" src="https://user-images.githubusercontent.com/1067855/228610863-c7f3ac0c-83de-4819-85ef-f91c634fffff.png">

<img width="973" alt="スクリーンショット 2023-03-30 1 49 38" src="https://user-images.githubusercontent.com/1067855/228610854-3b51db38-fd1e-4b3e-b8ec-82dc6fe74c98.png">

