### PR TITLE
Provide only the universal binary for Mac

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,18 +266,18 @@ jobs:
           cp build_x86_64/installer-macos.generated.pkgproj build_arm64/
           cp build_x86_64/installer-macos.generated.pkgproj build_universal/
 
-      - name: Package x86_64 Plugin
-        uses: ./plugin/.github/actions/package-plugin
-        with:
-          workingDirectory: ${{ github.workspace }}/plugin
-          target: x86_64
-          config: RelWithDebInfo
-          codesign: ${{ github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
-          notarize: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && steps.setup.outputs.haveNotarizationUser == 'true' }}
-          codesignIdent: ${{ env.CODESIGN_IDENT }}
-          installerIdent: ${{ env.CODESIGN_IDENT_INSTALLER }}
-          codesignUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
-          codesignPass: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
+      # - name: Package x86_64 Plugin
+      #   uses: ./plugin/.github/actions/package-plugin
+      #   with:
+      #     workingDirectory: ${{ github.workspace }}/plugin
+      #     target: x86_64
+      #     config: RelWithDebInfo
+      #     codesign: ${{ github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
+      #     notarize: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && steps.setup.outputs.haveNotarizationUser == 'true' }}
+      #     codesignIdent: ${{ env.CODESIGN_IDENT }}
+      #     installerIdent: ${{ env.CODESIGN_IDENT_INSTALLER }}
+      #     codesignUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
+      #     codesignPass: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
 
       - name: Extract x86_64 bundle
         working-directory: ${{ github.workspace }}/plugin
@@ -296,18 +296,18 @@ jobs:
         working-directory: ${{ github.workspace }}/plugin/release
         run: tar -xzf ${{ env.PLUGIN_NAME }}-macos-arm64.tar.gz
 
-      - name: Package ARM64 Plugin
-        uses: ./plugin/.github/actions/package-plugin
-        with:
-          workingDirectory: ${{ github.workspace }}/plugin
-          target: arm64
-          config: RelWithDebInfo
-          codesign: ${{ github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
-          notarize: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && steps.setup.outputs.haveNotarizationUser == 'true' }}
-          codesignIdent: ${{ env.CODESIGN_IDENT }}
-          installerIdent: ${{ env.CODESIGN_IDENT_INSTALLER }}
-          codesignUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
-          codesignPass: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
+      # - name: Package ARM64 Plugin
+      #   uses: ./plugin/.github/actions/package-plugin
+      #   with:
+      #     workingDirectory: ${{ github.workspace }}/plugin
+      #     target: arm64
+      #     config: RelWithDebInfo
+      #     codesign: ${{ github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
+      #     notarize: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' && steps.setup.outputs.haveNotarizationUser == 'true' }}
+      #     codesignIdent: ${{ env.CODESIGN_IDENT }}
+      #     installerIdent: ${{ env.CODESIGN_IDENT_INSTALLER }}
+      #     codesignUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
+      #     codesignPass: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
 
       - name: Extract arm64 bundle
         working-directory: ${{ github.workspace }}/plugin


### PR DESCRIPTION
So many people have tried to install ARM64 binary with Intel OBS.
The size of the universal installer is almost the same as the ARM64 and the x86_64 ones so I can say that there is no disadvantage to quitting providing the other installers.
By providing only the universal installer, the number of people who report "Simply not working" would decrease.