### PR TITLE
Issue template improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: '[BUG] '
+title: ''
 labels: 'bug'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,16 +1,18 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
+title: '[BUG] '
+labels: 'bug'
 assignees: ''
 
 ---
 
 **Describe the bug**
+
 A clear and concise description of what the bug is.
 
 **To Reproduce**
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
@@ -18,16 +20,26 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
+
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
+
 If applicable, add screenshots to help explain your problem.
 
+**Log and Crash Report**
+
+Upload your OBS log file here (`Help`>`Log Files`>`Show Log Files`) to help us find cause of the problem.
+
+If OBS is crashing, upload the crash report here as well (`Help`>`Crash Reports`>`Show Crash Reports`).
+
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Plugin Version [e.g. 0.5.1]
-- OBS Version [e.g. 28.02]
+
+ - OS: \[e.g. iOS\]
+ - Browser: \[e.g. chrome, safari\]
+ - Plugin Version: \[e.g. 0.5.1\]
+ - OBS Version: \[e.g. 28.02\]
 
 **Additional context**
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug'
+labels: ['bug']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'enhancement'
+labels: ['enhancement']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,24 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
+title: '[FEATURE REQUEST] '
+labels: 'enhancement'
 assignees: ''
 
 ---
 
 **Is your feature request related to a problem? Please describe.**
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 **Describe the solution you'd like**
+
 A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Additional context**
+
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: '[FEATURE REQUEST] '
+title: ''
 labels: 'enhancement'
 assignees: ''
 


### PR DESCRIPTION
This pull request makes the following changes to the issue templates:
- Adds tags automatically to new issues. This would make it easier to search for specific types of issues.
- Add a section to `bug_report.md` asking for an OBS log (and crash report, if applicable) to be uploaded
- Formatting and typo fixes.

I have one question about the current bug report template: Why does it ask for a browser version? I think we can remove this field to stop people like me just typing "N/A" or ignoring this field entirely.