### PR TITLE
Avoid using DML deprecated API

### DIFF
--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -202,7 +202,10 @@ static void createOrtSession(struct background_removal_filter *tf)
 #endif
 #ifdef _WIN32
     if (tf->useGPU == USEGPU_DML) {
-      Ort::ThrowOnError(OrtDmlApi::SessionOptionsAppendExecutionProvider_DML(sessionOptions, 0));
+      auto& api = Ort::GetApi();
+      OrtDmlApi* dmlApi = nullptr;
+      Ort::ThrowOnError(api.GetExecutionProviderApi("DML", ORT_API_VERSION, (const void**)&dmlApi));
+      Ort::ThrowOnError(dmlApi->SessionOptionsAppendExecutionProvider_DML(session_options, 0));
     }
 #endif
 #if defined(__APPLE__)

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -202,7 +202,7 @@ static void createOrtSession(struct background_removal_filter *tf)
 #endif
 #ifdef _WIN32
     if (tf->useGPU == USEGPU_DML) {
-      Ort::ThrowOnError(OrtDmlApi::OrtSessionOptionsAppendExecutionProvider_DML(sessionOptions, 0));
+      Ort::ThrowOnError(OrtDmlApi::SessionOptionsAppendExecutionProvider_DML(sessionOptions, 0));
     }
 #endif
 #if defined(__APPLE__)

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -202,7 +202,7 @@ static void createOrtSession(struct background_removal_filter *tf)
 #endif
 #ifdef _WIN32
     if (tf->useGPU == USEGPU_DML) {
-      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_DML(sessionOptions, 0));
+      Ort::ThrowOnError(OrtDmlApi::OrtSessionOptionsAppendExecutionProvider_DML(sessionOptions, 0));
     }
 #endif
 #if defined(__APPLE__)

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -202,9 +202,10 @@ static void createOrtSession(struct background_removal_filter *tf)
 #endif
 #ifdef _WIN32
     if (tf->useGPU == USEGPU_DML) {
-      auto& api = Ort::GetApi();
-      OrtDmlApi* dmlApi = nullptr;
-      Ort::ThrowOnError(api.GetExecutionProviderApi("DML", ORT_API_VERSION, (const void**)&dmlApi));
+      auto &api = Ort::GetApi();
+      OrtDmlApi *dmlApi = nullptr;
+      Ort::ThrowOnError(
+        api.GetExecutionProviderApi("DML", ORT_API_VERSION, (const void **)&dmlApi));
       Ort::ThrowOnError(dmlApi->SessionOptionsAppendExecutionProvider_DML(sessionOptions, 0));
     }
 #endif

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -205,7 +205,7 @@ static void createOrtSession(struct background_removal_filter *tf)
       auto& api = Ort::GetApi();
       OrtDmlApi* dmlApi = nullptr;
       Ort::ThrowOnError(api.GetExecutionProviderApi("DML", ORT_API_VERSION, (const void**)&dmlApi));
-      Ort::ThrowOnError(dmlApi->SessionOptionsAppendExecutionProvider_DML(session_options, 0));
+      Ort::ThrowOnError(dmlApi->SessionOptionsAppendExecutionProvider_DML(sessionOptions, 0));
     }
 #endif
 #if defined(__APPLE__)


### PR DESCRIPTION
> * [[deprecated]]
> * This export is deprecated.
> * The OrtSessionOptionsAppendExecutionProvider_DML export on the OrtDmlApi should be used instead.

https://github.com/microsoft/onnxruntime/blob/main/include/onnxruntime/core/providers/dml/dml_provider_factory.h#L33-L43