### PR TITLE
Add the link to AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,23 +74,8 @@ Use the CI scripts again
 $ ./.github/scripts/build-linux.sh
 ```
 
-#### Archlinux (DEPRECATED: Need to revise this section)
-A `PKGBUILD` file is provided for making the plugin package
-```sh
-$ cd scripts
-$ makepkg -s
-```
-
-Building for Arch in Docker (host OS e.g. MacOSX):
-```sh
-$ docker pull archlinux:latest
-$ docker run -it -v $(pwd):/src archlinux:latest /bin/bash
-# pacman -Sy --needed --noconfirm sudo fakeroot binutils gcc make
-# useradd builduser -m
-# passwd -d builduser
-# printf 'builduser ALL=(ALL) ALL\n' | tee -a /etc/sudoers
-# sudo -u builduser bash -c 'cd /src/scripts && makepkg -s'
-```
+#### Arch Linux
+The community maintains AUR packages: https://aur.archlinux.org/packages/obs-backgroundremoval
 
 ### Windows
 


### PR DESCRIPTION
It is enough for Arch Linux users to mention AUR.
Each Arch user builds an AUR package in their own way.