### PR TITLE
Make it easier to spot the openSUSE installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A plugin for [OBS Studio](https://obsproject.com/) that allows you to replace th
 - [Introduction](#introduction)
 - [Building](#building)
   - [MacOSX](#mac-osx)
-  - [Linux (Ubuntu, Arch)](#linux)
+  - [Linux (Ubuntu, Arch, openSUSE)](#linux)
   - [Windows](#windows)
 
 ## Download
@@ -16,7 +16,9 @@ On Ubuntu, there are two ways to install OBS and you have to use the correspondi
 - If you installed OBS via the official PPA, download the deb package from the [releases](https://github.com/royshil/obs-backgroundremoval/releases) page and install it directly.
 - If you installed OBS via FlatHub, run the following command: `flatpak install com.obsproject.Studio.Plugin.BackgroundRemoval`
 
-On linux distros other than Ubuntu, use the FlatHub installation of both OBS and this plugin.
+On openSUSE, please see [`docs/BUILDING-OPENSUSE.md`](docs/BUILDING-OPENSUSE.md).
+
+On other Linux distros, use the FlatHub installation of both OBS and this plugin.
 If you install OBS in a way other than FlatHub, you have to build this plugin by yourself (see instructions for building [below](#linux)).
 
 ## Requirements

--- a/docs/BUILDING-OPENSUSE.md
+++ b/docs/BUILDING-OPENSUSE.md
@@ -2,7 +2,7 @@
 
 NOTE: These instructions are unofficial and we will appreciate any pull requests to improve them.
 
-Please follow the steps to install obs-backgrounremoval plugin on OpenSUSE.
+Please follow the steps to install obs-backgroundremoval plugin on OpenSUSE.
 
 ### Install OBS
 


### PR DESCRIPTION
The very helpful openSUSE installation instructions were not referenced or linked from anywhere, so they were easy to miss.

So link to them from the top-level `README.md`.