### PR TITLE
Require OBS 28+ on the deb package

### DIFF
--- a/cmake/ObsPluginHelpers.cmake
+++ b/cmake/ObsPluginHelpers.cmake
@@ -505,7 +505,7 @@ else()
 
       set(CPACK_GENERATOR "DEB")
       set(CPACK_DEBIAN_PACKAGE_DEPENDS
-          "obs-studio (>= 27.0.0), libqt5core5a (>= 5.9.0~beta), libqt5gui5 (>= 5.3.0), libqt5widgets5 (>= 5.7.0)"
+          "obs-studio (>= 28.0.0)"
       )
 
       set(CPACK_OUTPUT_FILE_PREFIX ${CMAKE_SOURCE_DIR}/release)

--- a/cmake/ObsPluginHelpers.cmake
+++ b/cmake/ObsPluginHelpers.cmake
@@ -504,9 +504,7 @@ else()
       set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-linux-x86_64")
 
       set(CPACK_GENERATOR "DEB")
-      set(CPACK_DEBIAN_PACKAGE_DEPENDS
-          "obs-studio (>= 28.0.0)"
-      )
+      set(CPACK_DEBIAN_PACKAGE_DEPENDS "obs-studio (>= 28.0.0)")
 
       set(CPACK_OUTPUT_FILE_PREFIX ${CMAKE_SOURCE_DIR}/release)
 


### PR DESCRIPTION
This plugin actually needs OBS 28+.
Qt dependencies are built in the main OBS package so I want to omit them.