### PR TITLE
Remove zip from releases page

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -533,7 +533,6 @@ jobs:
           name: "${{ env.PLUGIN_NAME }} ${{ steps.metadata.outputs.version }}"
           body_path: ${{ github.workspace }}/CHECKSUMS.txt
           files: |
-            ${{ github.workspace }}/**/*.zip
             ${{ github.workspace }}/**/*.exe
             ${{ github.workspace }}/**/*.deb
             ${{ github.workspace }}/**/*.pkg


### PR DESCRIPTION
Many people on Windows are confused about whether they should use zip or exe and end up with a broken installation.
I suggest removing zip artifacts from the releases page and checking if there are people who want the zip archive.