### PR TITLE
Remove QtNetwork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ if(ENABLE_FRONTEND_API)
 endif()
 
 if(ENABLE_QT)
-  find_qt(COMPONENTS Network Widgets Core)
-  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Qt::Core Qt::Widgets Qt::Network)
+  find_qt(COMPONENTS Widgets Core)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Qt::Core Qt::Widgets)
   target_compile_options(
     ${CMAKE_PROJECT_NAME} PRIVATE $<$<C_COMPILER_ID:Clang,AppleClang>:-Wno-quoted-include-in-framework-header
                                   -Wno-comma>)

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -1,5 +1,3 @@
-#include <QtNetwork>
-
 #include "background-filter.h"
 
 #include <onnxruntime_cxx_api.h>

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -41,8 +41,6 @@ struct background_removal_filter : public filter_data {
 
 	gs_effect_t *effect;
 	gs_effect_t *kawaseBlurEffect;
-
-	QNetworkAccessManager qnam;
 };
 
 const char *background_filter_getname(void *unused)


### PR DESCRIPTION
We decided to use libcurl and not to use QtNetwork so I want to remove QtNetwork from this plugin.