### PR TITLE
Need zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ $ ./.github/scripts/build-linux.sh
 #### Arch Linux
 The community maintains AUR packages: https://aur.archlinux.org/packages/obs-backgroundremoval
 
+#### Fedora
+To compile on Fedora, you need to manage the dependencies manually. See [docs/BUILDING-FEDORA.md](docs/BUILDING-FEDORA.md) for more information.
+
 #### FlatHub
 The plugin is available on FlatHub: https://github.com/flathub/com.obsproject.Studio.Plugin.BackgroundRemoval
 

--- a/docs/BUILDING-FEDORA.md
+++ b/docs/BUILDING-FEDORA.md
@@ -8,7 +8,7 @@ sudo dnf groupinstall "Development Tools"
 Then, make sure you have the dependencies of this plugin installed:
 
 ```
-sudo dnf install cmake gcc-c++ ninja-build obs-studio-devel opencv-devel qt6-qtbase-devel
+sudo dnf install cmake gcc-c++ ninja-build obs-studio-devel opencv-devel qt6-qtbase-devel zsh
 ```
 
 Clone the repository and set up the submodules:


### PR DESCRIPTION
Sorry, forgot this one.
zsh is not necessarily installed on Fedora, but is needed to run the build script :smile: 

_Edit:_ added a mention in the top README file as well