### PR TITLE
Don't ignore the docs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !/build-aux
 !/cmake
 !/data
+!/docs
 !/src
 !/vendor
 !.clang-format


### PR DESCRIPTION
Just a suggestion - the `docs`directory is currently being ignored by git, making it hard to make changes.
Maybe remove it from exclusion? :smile: 
(It has been like this since [the commit on June 29th](https://github.com/royshil/obs-backgroundremoval/commit/c9d86548bc752b0eb157d47fd543598d05e712a2#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947))