### PR TITLE
C17 is only supported CMake 3.21+

### DIFF
--- a/cmake/common/compiler_common.cmake
+++ b/cmake/common/compiler_common.cmake
@@ -3,7 +3,7 @@
 include_guard(GLOBAL)
 
 # Set C and C++ language standards to C17 and C++17
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.21)
   set(CMAKE_C_STANDARD 17)
 else()
   set(CMAKE_C_STANDARD 11)


### PR DESCRIPTION
I have a build issue on openSUSE Leap 15.5 that its build system does not support C17.
The CMake provided by openSUSE Leap 15.5 is 3.20 and this version does not understand C17.
https://cmake.org/cmake/help/latest/prop_tgt/C_STANDARD.html
This PR will fix the build on openSUSE Leap.