### PR TITLE
Generate static libraries for HttpClient

### DIFF
--- a/src/update-checker/CurlClient/CMakeLists.txt
+++ b/src/update-checker/CurlClient/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(CurlClient CurlClient.cpp)
+add_library(CurlClient STATIC CurlClient.cpp)
 target_link_libraries(CurlClient PRIVATE OBS::libobs plugin-support)
 target_include_directories(CurlClient PRIVATE "${CMAKE_SOURCE_DIR}/src")
 

--- a/src/update-checker/URLSessionClient/CMakeLists.txt
+++ b/src/update-checker/URLSessionClient/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(URLSessionClient URLSessionClient.mm)
+add_library(URLSessionClient STATIC URLSessionClient.mm)
 target_link_libraries(URLSessionClient PRIVATE OBS::libobs plugin-support)
 target_include_directories(URLSessionClient PRIVATE "${CMAKE_SOURCE_DIR}/src")

--- a/src/update-checker/WinRTHttpClient/CMakeLists.txt
+++ b/src/update-checker/WinRTHttpClient/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(WinRTHttpClient WinRTHttpClient.cpp)
+add_library(WinRTHttpClient STATIC WinRTHttpClient.cpp)
 set_target_properties(
   WinRTHttpClient
   PROPERTIES CXX_STANDARD 17


### PR DESCRIPTION
This change is needed to build on openSUSE Leap