### PR TITLE
BUILDING-FEDORA.md: add curl-devel

### DIFF
--- a/docs/BUILDING-FEDORA.md
+++ b/docs/BUILDING-FEDORA.md
@@ -8,7 +8,7 @@ sudo dnf groupinstall "Development Tools"
 Then, make sure you have the dependencies of this plugin installed:
 
 ```
-sudo dnf install cmake gcc-c++ ninja-build obs-studio-devel opencv-devel qt6-qtbase-devel zsh
+sudo dnf install cmake gcc-c++ ninja-build obs-studio-devel opencv-devel qt6-qtbase-devel zsh curl-devel
 ```
 
 Clone the repository and set up the submodules:


### PR DESCRIPTION
`curl-devel` is needed on fedora38