### PR TITLE
Remove USE_SYSTEM_CURL

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -83,8 +83,7 @@
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_POSITION_INDEPENDENT_CODE": true,
         "ENABLE_FRONTEND_API": true,
-        "ENABLE_QT": true,
-        "USE_SYSTEM_CURL": true
+        "ENABLE_QT": true
       }
     },
     {
@@ -114,8 +113,7 @@
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_POSITION_INDEPENDENT_CODE": true,
         "ENABLE_FRONTEND_API": true,
-        "ENABLE_QT": true,
-        "USE_SYSTEM_CURL": true
+        "ENABLE_QT": true
       }
     },
     {


### PR DESCRIPTION
The cache variable USE_SYSTEM_CURL is no longer used.
This PR removes this cache variable from CMakePresets.json