### PR TITLE
Fix guide page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Additional tutorial videos:
 
 ## Download
 
-Check out the [guide page](https://locaal-ai.github.io/obs-backgroundremoval) for downloads and install instructions for **Windows** and **MacOS**.
+Check out the [guide page](https://royshil.github.io/obs-backgroundremoval/) for downloads and install instructions for **Windows** and **MacOS**.
 
 ### Linux Installation
 


### PR DESCRIPTION
The current like to "guide page" links to a 404. I replaced with this link: https://royshil.github.io/obs-backgroundremoval/