### PR TITLE
chore: bump version to 1.3.4 for release

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
   },
   "name": "obs-backgroundremoval",
   "displayName": "OBS Background Removal",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": "Roy Shilkrot",
   "website": "https://royshil.github.io/obs-backgroundremoval/",
   "email": "roy.shil@gmail.com"


### PR DESCRIPTION
## Changes between 1.3.3 and HEAD

The following updates were made after version 1.3.3 up to the latest commit on `main`:

### 1. Version Bump for Release
- **chore: bump version to 1.3.4 for release**
  - The project version was incremented to 1.3.4 in preparation for a new release.

### 2. Bug Fixes

- **Fix CUDA option not appearing on Linux due to preprocessor macro typo** ([#713](https://github.com/royshil/obs-backgroundremoval/pull/713))
  - Corrected a typo in a preprocessor macro: changed `HAVE_ONNXRUNTIME_CUDA_CP` to `HAVE_ONNXRUNTIME_CUDA_EP`.
  - This resolves an issue where the CUDA option was not shown on Linux due to the incorrect macro.

- **Fix macOS download page serving .deb instead of .pkg** ([#708](https://github.com/royshil/obs-backgroundremoval/pull/708))
  - Fixed the macOS download link to properly serve the `.pkg` installer instead of incorrectly offering a `.deb` package.

---

#### Summary Table

| Commit                                    | Description                        |
|--------------------------------------------|------------------------------------|
| 0daff8c8                                  | Bump version to 1.3.4              |
| 22367cb5 ([#713](https://github.com/royshil/obs-backgroundremoval/pull/713)) | Fix CUDA preprocessor macro typo   |
| 1ce56935 ([#708](https://github.com/royshil/obs-backgroundremoval/pull/708)) | Fix macOS download link extension  |

No major new features or breaking changes were introduced in these commits. The updates are focused on bug fixes and preparing for the next release.