### PR TITLE
Update issue templates to OBS Background Removal

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     id: md_welcome
     attributes:
       value: |
-        ## 🐞 Bug Report for Live Background Removal Lite
+        ## 🐞 Bug Report for OBS Background Removal
 
         Please fill out **all required fields**. Incomplete reports may be closed without investigation.
         - Attach an OBS log file (see below).
@@ -50,7 +50,7 @@ body:
     id: plugin_version
     attributes:
       label: Plugin Version
-      description: What version of Live Background Removal Lite are you using?
+      description: What version of OBS Background Removal are you using?
       placeholder: "e.g., 1.0.0, 1.0.0-beta1, git-abcdef"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
     id: md_welcome
     attributes:
       value: |
-        ## 💡 Feature Request for Live Background Removal Lite
+        ## 💡 Feature Request for OBS Background Removal
 
         Please fill out the form below to suggest a new feature or improvement.
         - Check existing issues before submitting a new one.


### PR DESCRIPTION
This pull request updates the issue templates to reflect a change in the plugin's name from "Live Background Removal Lite" to "OBS Background Removal." The updates ensure consistency and clarity for users submitting bug reports or feature requests.

**Issue template updates:**

* Updated the bug report template title and plugin version description to use "OBS Background Removal" instead of "Live Background Removal Lite". [[1]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL10-R10) [[2]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL53-R53)
* Updated the feature request template title to use "OBS Background Removal" instead of "Live Background Removal Lite".Renamed references from 'Live Background Removal Lite' to 'OBS Background Removal' in bug report and feature request templates for consistency with the current project name.