### PR TITLE
Remove source tarball packaging and upload

### DIFF
--- a/.github/scripts/package-ubuntu
+++ b/.github/scripts/package-ubuntu
@@ -150,11 +150,6 @@ ${_usage_host:-}"
   local -a cmake_args=()
   if (( _loglevel > 1 )) cmake_args+=(--verbose)
 
-  log_group "Creating source tarball for ${product_name}..."
-  pushd ${project_root}
-  cmake --build build_${target##*-} --config ${config} -t package_source ${cmake_args}
-  popd
-
   if (( package )) {
     log_group "Packaging ${product_name}..."
     pushd ${project_root}

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -301,12 +301,6 @@ jobs:
           config: ${{ needs.check-event.outputs.config }}
           package: ${{ fromJSON(needs.check-event.outputs.package) }}
 
-      - name: Upload Source Tarball 🗜️
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-sources-${{ needs.check-event.outputs.commitHash }}
-          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-source.*
-
       - name: Upload Artifacts 📡
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -74,7 +74,6 @@ jobs:
             'windows-x64;zip|exe'
             'macos-universal;tar.xz|pkg'
             'ubuntu-24.04-x86_64;tar.xz|deb|ddeb'
-            'sources;tar.xz'
           )
 
           for variant_data in "${variants[@]}"; do
@@ -110,9 +109,7 @@ jobs:
           name: ${{ needs.build-project.outputs.pluginName }} ${{ steps.check.outputs.version }}
           body_path: ${{ github.workspace }}/CHECKSUMS.txt
           files: |
-            ${{ github.workspace }}/*.exe
             ${{ github.workspace }}/*.zip
             ${{ github.workspace }}/*.pkg
             ${{ github.workspace }}/*.deb
             ${{ github.workspace }}/*.ddeb
-            ${{ github.workspace }}/*.tar.xz


### PR DESCRIPTION
Remove creating source.tar.xz because it includes binaries, and we keep our code buildable with git clone.