### PR TITLE
Update BUILDING-FEDORA.md

### DIFF
--- a/docs/BUILDING-FEDORA.md
+++ b/docs/BUILDING-FEDORA.md
@@ -18,7 +18,8 @@ sudo dnf install \
   curl-devel \
   gcc-c++ \
   obs-studio-devel \
-  opencv-devel
+  opencv-devel \
+  onnxruntime-devel
 ```
 
 Run the following command to compile the plugin:  


### PR DESCRIPTION
I needed to install onnxruntime-devel (and onnxruntime) as well before I got it to work on Fedora 43 (with GNOME).

## Pull Request Checklist

Please read our latest [CONTRIBUTING.md](https://github.com/royshil/obs-backgroundremoval/blob/main/CONTRIBUTING.md).

- [x] I have read the latest CONTRIBUTING.md.
- [x] I have acknowledged the licensing and patent grant policy.
- [x] I have included the required license headers.
- [x] I am confident with my code integrity.
- [x] I have signed off and verified all my commits.
