### PR TITLE
Fix create-release

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -520,10 +520,13 @@ jobs:
       artifact-metadata: write
       attestations: write
       contents: write
+      id-token: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Extract plugin metadata
         id: metadata
@@ -531,11 +534,8 @@ jobs:
 
       - name: Select secure directory
         id: secure-dir
-        run: |
-          {
-            printf 'artifacts='
-            mktemp -d -p "$RUNNER_TEMP" "artifacts.XXXXXXXXXX"
-          } >> "$GITHUB_OUTPUT"
+        shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
+        run: printf 'artifacts=%s\n' "$(mktemp -d -p "$RUNNER_TEMP" "artifacts.XXXXXXXXXX")" >> "$GITHUB_OUTPUT"
 
       - name: Download plugin binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -550,23 +550,29 @@ jobs:
         with:
           subject-path: ${{ steps.secure-dir.outputs.artifacts }}/*
 
-      - name: Create Draft Release
-        shell: bash
+      - name: Upload assets to the draft release
+        shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
         working-directory: ${{ steps.secure-dir.outputs.artifacts }}
         run: |
-          set -euo pipefail
-          shopt -s nullglob
+          # Output the existing release info, or create a new draft release if not exists.
+          if !gh release view "$GITHUB_REF_NAME"; then
+            gh release create "$GITHUB_REF_NAME" --draft --notes-from-tag --title "$GITHUB_REF_NAME" --verify-tag
+          fi
 
-          TAG_NAME=${GITHUB_REF#refs/tags/}
+          ASSETS=("$BUNDLE_PATH")
 
-          GH_RELEASE_CREATE_ARGS=(
-            "$BUNDLE_PATH"
-            --draft
-            --generate-notes
-            --title "$TAG_NAME"
-          )
+          for f in *; do
+            case "$f" in
+            *-windows-x64.zip) ASSETS+=("$f#ZIP Binary for Windows (x64)") ;;
+            *-windows-x64-pdb.zip) ASSETS+=("$f") ;;
+            *-macos-universal.pkg) ASSETS+=("$f#PKG Binary for macOS (Universal)") ;;
+            *-macos-universal.dSYM.tar.xz) ASSETS+=("$f") ;;
+            *-x86_64-linux-gnu.deb) ASSETS+=("$f#DEB Binary for Ubuntu (x86_64)") ;;
+            *-x86_64-linux-gnu-dbgsym.ddeb) ASSETS+=("$f") ;;
+            esac
+          done
 
-          gh release create "$TAG_NAME" ./* "${GH_RELEASE_CREATE_ARGS[@]}"
+          gh release upload "$GITHUB_REF_NAME" "${ASSETS[@]}" --clobber


### PR DESCRIPTION
The release process of 1.4.0 has failed at the attest step of the create-release job. The root cause is missing id-token permission, but there are still some problems to prevent this job from working. We need to solve this problem to proceed the 1.4.0 release first.

Failure Log: https://github.com/royshil/obs-backgroundremoval/actions/runs/23522897405/job/68471269519#step:6:12

## Pull Request Checklist

Please read our latest [CONTRIBUTING.md](https://github.com/royshil/obs-backgroundremoval/blob/main/CONTRIBUTING.md).

- [x] I have read the latest CONTRIBUTING.md.
- [x] I have acknowledged the licensing and patent grant policy.
- [x] I have included the required license headers.
- [x] I am confident with my code integrity.
- [x] I have signed off and verified all my commits.
