### PR TITLE
Fix gh release create call

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Extract plugin buildspec
@@ -73,11 +74,10 @@ jobs:
           BUNDLE_PATH: '${{ steps.attest.outputs.bundle-path }}'
           GH_REPO: '${{ github.repository }}'
           GH_TOKEN: '${{ github.token }}'
-        working-directory: ${{ steps.secure-dir.outputs.ARTIFACTS_DIR }}
         run: |
           # Output the existing release info, or create a new draft release if not exists.
           if ! gh release view "$GITHUB_REF_NAME"; then
-            gh release create "$GITHUB_REF_NAME" --draft --notes-from-tag --title "$GITHUB_REF_NAME" --verify-tag
+            gh release create "$GITHUB_REF_NAME" --draft --notes "" --title "$GITHUB_REF_NAME" --verify-tag
           fi
 
           ASSETS=("$BUNDLE_PATH")


### PR DESCRIPTION
- Holds all the history of tree
- No need to generate something on GHA

## Pull Request Checklist

Please read our latest [CONTRIBUTING.md](https://github.com/royshil/obs-backgroundremoval/blob/main/CONTRIBUTING.md).

- [x] I have read the latest CONTRIBUTING.md.
- [x] I have acknowledged the licensing and patent grant policy.
- [x] I have included the required license headers.
- [x] I am confident with my code integrity.
- [x] I have signed off and verified all my commits.
