### PR TITLE
Update vcpkg dependencies

### DIFF
--- a/.github/workflows/plugin-build-macos.yml
+++ b/.github/workflows/plugin-build-macos.yml
@@ -6,8 +6,7 @@
 
 # file: .github/workflows/plugin-build-macos.yml
 # author: Kaito Udagawa <umireon@kaito.tokyo>
-# version: 1.1.0
-# date: 2026-04-04
+# date: 2026-05-21
 
 on:
   workflow_call:
@@ -33,6 +32,10 @@ on:
         description: Whether to enable code signing and notarization steps.
         required: true
         type: boolean
+      DEVELOPER_DIR:
+        description: The value of DEVELOPER_DIR environment variable.
+        required: true
+        type: string
 
     secrets:
       MACOS_NOTARIZATION_PASSWORD:
@@ -60,11 +63,13 @@ jobs:
       contents: read
 
     env:
+
       CLEAN_BASH_ENV: '${{ github.workspace }}/.github/scripts/clean-env-macos.bash'
-      DEVELOPER_DIR: '/Applications/Xcode_16.4.app'
+      DEVELOPER_DIR: '${{ inputs.DEVELOPER_DIR }}'
       FILTERED_PATH: '/opt/homebrew/opt/xcbeautify/bin:/opt/homebrew/opt/ninja/bin:/opt/homebrew/opt/cmake/bin:/opt/homebrew/opt/curl/bin:/opt/homebrew/opt/wget/bin:/usr/bin:/bin:/usr/sbin:/sbin'
       ORT_CCACHE_DIR: '${{ github.workspace }}/.ort_ccache'
-      ROOT_VCPKG_ROOT: '${{ github.workspace }}/vcpkg'
+      VCPKG_BINARY_SOURCES: '${{ inputs.VCPKG_BINARY_SOURCES }}'
+      VCPKG_VERSION: '${{ inputs.vcpkg-version }}'
 
     steps:
       - name: Output Image Metadata
@@ -82,6 +87,14 @@ jobs:
         id: buildspec
         uses: ./.github/actions/extract-buildspec
 
+      - name: Checkout vcpkg
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: microsoft/vcpkg
+          ref: ${{ env.VCPKG_VERSION }}
+          persist-credentials: false
+          path: vcpkg
+
       - name: Set up Python for build requirements
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -96,48 +109,57 @@ jobs:
 
       # ASSERT: The directory of ccache executable is prepended to the PATH even if PATH is overridden in the env section.
 
-      - name: Checkout vcpkg
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: microsoft/vcpkg
-          ref: ${{ inputs.vcpkg-version }}
-          persist-credentials: false
-          path: ${{ env.ROOT_VCPKG_ROOT }}
+      - name: Print CMake version
+        shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
+        run: |
+          cmake --version
+
+      - name: Print Ninja version
+        shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
+        run: |
+          ninja --version
+
+      - name: Print Xcode version
+        shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
+        run: |
+          xcodebuild -version
+
+      - name: Print xcbeautify version
+        shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
+        run: |
+          xcbeautify --version
 
       - name: Run bootstrap-vcpkg.sh
         shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
-        env:
-          BASH_ENV: '${{ env.CLEAN_BASH_ENV }}'
-          PATH: '${{ env.FILTERED_PATH }}'
-          VCPKG_ROOT: '${{ env.ROOT_VCPKG_ROOT }}'
         run: |
-          "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
+          ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
 
       - name: Install dependencies from vcpkg (macOS arm64)
         shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
-        env:
-          BASH_ENV: '${{ env.CLEAN_BASH_ENV }}'
-          PATH: '${{ env.FILTERED_PATH }}'
-          VCPKG_BINARY_SOURCES: '${{ inputs.VCPKG_BINARY_SOURCES }}'
-          VCPKG_ROOT: '${{ env.ROOT_VCPKG_ROOT }}'
         run: |
-          "$VCPKG_ROOT/vcpkg" install --x-install-root=.deps_vendor/vcpkg_installed_arm64 --triplet=arm64-osx-obs
+          vars=(
+            DEVELOPER_DIR="$DEVELOPER_DIR"
+            HOME="$HOME"
+            PATH=/usr/bin:/bin:/usr/sbin:/sbin
+            VCPKG_BINARY_SOURCES="$VCPKG_BINARY_SOURCES"
+            VCPKG_ROOT="$GITHUB_WORKSPACE/vcpkg"
+          )
+          env -i "${vars[@]}" ./vcpkg/vcpkg install --triplet=arm64-osx-obs --x-install-root=./.deps_vendor/vcpkg_installed_arm64
 
       - name: Install dependencies from vcpkg (macOS x86_64)
         shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
-        env:
-          BASH_ENV: '${{ env.CLEAN_BASH_ENV }}'
-          PATH: '${{ env.FILTERED_PATH }}'
-          VCPKG_BINARY_SOURCES: '${{ inputs.VCPKG_BINARY_SOURCES }}'
-          VCPKG_ROOT: '${{ env.ROOT_VCPKG_ROOT }}'
         run: |
-          "$VCPKG_ROOT/vcpkg" install --x-install-root=.deps_vendor/vcpkg_installed_x64 --triplet=x64-osx-obs
+          vars=(
+            DEVELOPER_DIR="$DEVELOPER_DIR"
+            HOME="$HOME"
+            PATH=/usr/bin:/bin:/usr/sbin:/sbin
+            VCPKG_BINARY_SOURCES="$VCPKG_BINARY_SOURCES"
+            VCPKG_ROOT="$GITHUB_WORKSPACE/vcpkg"
+          )
+          env -i "${vars[@]}" ./vcpkg/vcpkg install --triplet=x64-osx-obs --x-install-root=./.deps_vendor/vcpkg_installed_x64
 
       - name: Lipo vcpkg (macOS)
         shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
-        env:
-          BASH_ENV: '${{ env.CLEAN_BASH_ENV }}'
-          PATH: '${{ env.FILTERED_PATH }}'
         run: |
           ./scripts/lipo_vcpkg_macos.sh \
             ./.deps_vendor/vcpkg_installed_universal/universal-osx-obs \
@@ -146,9 +168,6 @@ jobs:
 
       - name: Download dependencies (macOS)
         shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
-        env:
-          BASH_ENV: '${{ env.CLEAN_BASH_ENV }}'
-          PATH: '${{ env.FILTERED_PATH }}'
         run: |
           cmake -P ./scripts/download_deps.cmake
 

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -6,6 +6,10 @@
 
 name: Plugin CI
 
+# file: .github/workflows/plugin.yml
+# author: Kaito Udagawa <umireon@kaito.tokyo>
+# date: 2026-05-21
+
 on:
   pull_request:
     branches: [main]
@@ -20,34 +24,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  config:
+    permissions: {}
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    outputs:
+      ORT_VERSION: ${{ steps.config.outputs.ORT_VERSION }}
+      VCPKG_BINARY_SOURCES: ${{ steps.config.outputs.VCPKG_BINARY_SOURCES }}
+      VCPKG_VERSION: ${{ steps.config.outputs.VCPKG_VERSION }}
+    steps:
+      - name: Output config
+        id: config
+        shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
+        run: |
+          echo 'ORT_VERSION=v1.24.4' >> "${GITHUB_OUTPUT}"
+          echo 'VCPKG_BINARY_SOURCES=clear;http,https://vcpkg-obs.kaito.tokyo/{name}/{version}/{sha},read' >> "${GITHUB_OUTPUT}"
+          echo 'VCPKG_VERSION=2026.04.27' >> "${GITHUB_OUTPUT}"
+
   build-windows:
+    needs: config
     permissions:
       contents: read
     uses: ./.github/workflows/plugin-build-windows.yml
     with:
-      VCPKG_BINARY_SOURCES: 'clear;http,https://vcpkg-obs.kaito.tokyo/{name}/{version}/{sha}'
-      vcpkg-version: '2025.08.27'
-      ort-version: v1.24.4
+      VCPKG_BINARY_SOURCES: ${{ needs.config.outputs.VCPKG_BINARY_SOURCES }}
+      vcpkg-version: ${{ needs.config.outputs.VCPKG_VERSION }}
+      ort-version: ${{ needs.config.outputs.ORT_VERSION }}
 
   build-macos:
+    needs: config
     permissions:
       contents: read
     uses: ./.github/workflows/plugin-build-macos.yml
     with:
-      VCPKG_BINARY_SOURCES: 'clear;http,https://vcpkg-obs.kaito.tokyo/{name}/{version}/{sha}'
-      vcpkg-version: '2025.08.27'
-      ort-version: v1.24.4
+      VCPKG_BINARY_SOURCES: ${{ needs.config.outputs.VCPKG_BINARY_SOURCES }}
+      vcpkg-version: ${{ needs.config.outputs.VCPKG_VERSION }}
+      ort-version: ${{ needs.config.outputs.ORT_VERSION }}
       codesign-enabled: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) }}
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app
     secrets: inherit
 
   build-ubuntu:
+    needs: config
     permissions:
       contents: read
     uses: ./.github/workflows/plugin-build-ubuntu.yml
     with:
-      VCPKG_BINARY_SOURCES: 'clear;http,https://vcpkg-obs.kaito.tokyo/{name}/{version}/{sha}'
-      vcpkg-version: '2025.08.27'
-      ort-version: v1.24.4
+      VCPKG_BINARY_SOURCES: ${{ needs.config.outputs.VCPKG_BINARY_SOURCES }}
+      vcpkg-version: ${{ needs.config.outputs.VCPKG_VERSION }}
+      ort-version: ${{ needs.config.outputs.ORT_VERSION }}
 
   accept-plugin:
     name: Accept Plugin CI

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,14 +2,14 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "git",
-    "baseline": "4ef2a7144d00c2f446029b9700e701a3094b8bfb",
+    "baseline": "f7f94113c3b629c01df3d49d5edebae6d598c78c",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [
     {
       "kind": "git",
-      "baseline": "1e678209cf07f4b413d3e05431126808bb4954f2",
-      "repository": "https://github.com/kaito-tokyo/vcpkg-obs-kaito-tokyo",
+      "baseline": "a0f06e896a158885fb426e5a91afe72b9b10526b",
+      "repository": "https://github.com/kaito-tokyo/vcpkg-registry-kaito-tokyo",
       "packages": [
         "wolfssl"
       ]


### PR DESCRIPTION
- vcpkg: 2026.04.27
- Update baseline
- Migrated to https://github.com/kaito-tokyo/vcpkg-registry-kaito-tokyo (Cache and registry were separated.)

## Pull Request Checklist

Please read our latest [CONTRIBUTING.md](https://github.com/royshil/obs-backgroundremoval/blob/main/CONTRIBUTING.md).

- [x] I have read the latest CONTRIBUTING.md.
- [x] I have acknowledged the licensing and patent grant policy.
- [x] I have included the required license headers.
- [x] I am confident with my code integrity.
- [x] I have signed off and verified all my commits.
