### PR TITLE
Fix false positive update alert when local version is newer

### DIFF
--- a/src/update-checker/update-checker.cpp
+++ b/src/update-checker/update-checker.cpp
@@ -13,8 +13,7 @@
 #include "../plugin-support.h"
 
 #include <mutex>
-#include <sstream>
-#include <vector>
+#include <regex>
 #include <algorithm>
 
 extern "C" const char *PLUGIN_VERSION;
@@ -24,36 +23,33 @@ static std::mutex latestVersionMutex;
 
 static bool is_newer_version(const std::string& remote, const std::string& local)
 {
-	std::vector<int> remote_parts;
-	std::vector<int> local_parts;
-	std::string part;
+	std::regex version_regex(R"(^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z]+)(?:\.?(\d+))?)?$)");
+	std::smatch remote_match;
+	std::smatch local_match;
 
-	std::stringstream ss_remote(remote);
-	while (std::getline(ss_remote, part, '.')) {
-		try {
-			remote_parts.push_back(std::stoi(part));
-		} catch (...) {
-			remote_parts.push_back(0);
-		}
+	bool remote_valid = std::regex_match(remote, remote_match, version_regex);
+	bool local_valid = std::regex_match(local, local_match, version_regex);
+
+	if (!remote_valid || !local_valid) {
+		// Fallback to basic string comparison if regex fails
+		return remote > local;
 	}
 
-	std::stringstream ss_local(local);
-	while (std::getline(ss_local, part, '.')) {
-		try {
-			local_parts.push_back(std::stoi(part));
-		} catch (...) {
-			local_parts.push_back(0);
-		}
-	}
+	int remote_major = std::stoi(remote_match[1].str());
+	int remote_minor = std::stoi(remote_match[2].str());
+	int remote_patch = std::stoi(remote_match[3].str());
 
-	size_t max_parts = std::max(remote_parts.size(), local_parts.size());
-	for (size_t i = 0; i < max_parts; ++i) {
-		int r = i < remote_parts.size() ? remote_parts[i] : 0;
-		int l = i < local_parts.size() ? local_parts[i] : 0;
-		if (r > l) return true;
-		if (r < l) return false;
+	int local_major = std::stoi(local_match[1].str());
+	int local_minor = std::stoi(local_match[2].str());
+	int local_patch = std::stoi(local_match[3].str());
+
+	if (remote_major != local_major) {
+		return remote_major > local_major;
 	}
-	return false;
+	if (remote_minor != local_minor) {
+		return remote_minor > local_minor;
+	}
+	return remote_patch > local_patch;
 }
 
 void check_update(void)

--- a/src/update-checker/update-checker.cpp
+++ b/src/update-checker/update-checker.cpp
@@ -13,11 +13,48 @@
 #include "../plugin-support.h"
 
 #include <mutex>
+#include <sstream>
+#include <vector>
+#include <algorithm>
 
 extern "C" const char *PLUGIN_VERSION;
 
 static std::string latestVersionForUpdate;
 static std::mutex latestVersionMutex;
+
+static bool is_newer_version(const std::string& remote, const std::string& local)
+{
+	std::vector<int> remote_parts;
+	std::vector<int> local_parts;
+	std::string part;
+
+	std::stringstream ss_remote(remote);
+	while (std::getline(ss_remote, part, '.')) {
+		try {
+			remote_parts.push_back(std::stoi(part));
+		} catch (...) {
+			remote_parts.push_back(0);
+		}
+	}
+
+	std::stringstream ss_local(local);
+	while (std::getline(ss_local, part, '.')) {
+		try {
+			local_parts.push_back(std::stoi(part));
+		} catch (...) {
+			local_parts.push_back(0);
+		}
+	}
+
+	size_t max_parts = std::max(remote_parts.size(), local_parts.size());
+	for (size_t i = 0; i < max_parts; ++i) {
+		int r = i < remote_parts.size() ? remote_parts[i] : 0;
+		int l = i < local_parts.size() ? local_parts[i] : 0;
+		if (r > l) return true;
+		if (r < l) return false;
+	}
+	return false;
+}
 
 void check_update(void)
 {
@@ -41,8 +78,8 @@ void check_update(void)
 		}
 		obs_log(LOG_INFO, "Latest release is %s", info.version.c_str());
 
-		if (info.version == PLUGIN_VERSION) {
-			// No update available, latest version is the same as the current version
+		if (!is_newer_version(info.version, PLUGIN_VERSION)) {
+			// No update available, latest version is not newer than the current version
 			std::lock_guard<std::mutex> lock(latestVersionMutex);
 			latestVersionForUpdate.clear();
 			return;


### PR DESCRIPTION
### Description
This PR fixes a bug where the plugin incorrectly alerts the user that an update is available when the locally installed version is actually newer than the latest version fetched from the GitHub API. 

Currently, users running a newer local version (e.g., `1.4.0`) are prompted with `🚀 Update available! (1.3.7)` because the update checking logic in `update-checker.cpp` only checks for strict equality (`info.version == PLUGIN_VERSION`). If the versions do not match, it assumes a new update is available.

### Solution
1. Introduced a semantic version comparison helper `is_newer_version` that splits both the remote and local version strings by `.` and compares the integer components sequentially.
2. Updated the comparison inside the callback of `check_update` to only set `latestVersionForUpdate` if the fetched remote version is strictly newer than the currently installed `PLUGIN_VERSION`.

---

## Pull Request Checklist

Please read our latest [CONTRIBUTING.md](https://github.com/royshil/obs-backgroundremoval/blob/main/CONTRIBUTING.md).

- [x] I have read the latest CONTRIBUTING.md.
- [x] I have acknowledged the licensing and patent grant policy.
- [x] I have included the required license headers.
- [x] I am confident with my code integrity.
- [x] I have signed off and verified all my commits.
