### PR TITLE
Fix GPU support again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.cache/
 .venv/
 .vscode/
 /.ccache*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,8 @@ block(PROPAGATE onnxruntime_FOUND HAVE_ONNXRUNTIME_CUDA_EP HAVE_ONNXRUNTIME_ROCM
   endif()
 
   ### Check execution provider availability
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
+
   cmake_push_check_state(RESET)
   set(CMAKE_REQUIRED_LIBRARIES onnxruntime::onnxruntime)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ endblock()
 set(OS_LINUX ${OS_LINUX_DETECTED} CACHE STRING "Linux variant: Linux Debian Ubuntu FALSE")
 
 include(GNUInstallDirs)
+include(CheckCXXSymbolExists)
+include(CMakePushCheckState)
 
 ### Global configurations
 set(CMAKE_C_STANDARD 17)
@@ -150,7 +152,7 @@ block(PROPAGATE OpenCV_FOUND)
   endif()
 endblock()
 
-block(PROPAGATE onnxruntime_FOUND)
+block(PROPAGATE onnxruntime_FOUND HAVE_ONNXRUNTIME_CUDA_EP HAVE_ONNXRUNTIME_ROCM_EP)
   set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS ON)
 
   if(POLICY CMP0167)
@@ -174,54 +176,81 @@ block(PROPAGATE onnxruntime_FOUND)
   if(NOT TARGET onnxruntime::onnxruntime)
     add_library(onnxruntime::onnxruntime ALIAS onnxruntime)
   endif()
+
+  ### Check execution provider availability
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_LIBRARIES onnxruntime::onnxruntime)
+
+  function(check_onnxruntime_execution_provider result symbol)
+    set(found FALSE)
+    set(index 0)
+
+    foreach(header IN LISTS ARGN)
+      math(EXPR index "${index} + 1")
+      set(check_variable "${result}_${index}")
+      check_cxx_symbol_exists("${symbol}" "${header}" "${check_variable}")
+
+      if(${check_variable})
+        set(found TRUE)
+        break()
+      endif()
+    endforeach()
+
+    set(${result} "${found}" PARENT_SCOPE)
+  endfunction()
+
+  check_onnxruntime_execution_provider(
+    HAVE_ONNXRUNTIME_CUDA_EP
+    OrtSessionOptionsAppendExecutionProvider_CUDA
+    onnxruntime_c_api.h
+    onnxruntime/onnxruntime_c_api.h
+    onnxruntime/core/session/onnxruntime_c_api.h
+    cuda_provider_factory.h
+    onnxruntime/cuda_provider_factory.h
+    onnxruntime/core/providers/cuda/cuda_provider_factory.h
+  )
+
+  check_onnxruntime_execution_provider(
+    HAVE_ONNXRUNTIME_ROCM_EP
+    OrtSessionOptionsAppendExecutionProvider_ROCM
+    onnxruntime_c_api.h
+    onnxruntime/onnxruntime_c_api.h
+    onnxruntime/core/session/onnxruntime_c_api.h
+    rocm_provider_factory.h
+    onnxruntime/rocm_provider_factory.h
+    onnxruntime/core/providers/rocm/rocm_provider_factory.h
+  )
+
+  cmake_pop_check_state()
 endblock()
 
-# ONNX Runtime installs its public headers both flattened under <prefix>/include/onnxruntime
-# and nested under core/session, but which of those directories ends up on the include search
-# path depends on the release and on how the package was built. Probe the two spellings the
-# sources can use and let them switch on the result rather than pinning one layout.
-include(CheckCXXSourceCompiles)
-
-# A static library try_compile only compiles, so the whole ONNX Runtime does not have to link
-# just to resolve a header.
-set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-set(CMAKE_REQUIRED_LIBRARIES onnxruntime::onnxruntime)
-
-check_cxx_source_compiles("#include <onnxruntime_cxx_api.h>" HAVE_ONNXRUNTIME_CXX_API_H)
-check_cxx_source_compiles("#include <onnxruntime/onnxruntime_cxx_api.h>" HAVE_ONNXRUNTIME_ONNXRUNTIME_CXX_API_H)
-
-unset(CMAKE_REQUIRED_LIBRARIES)
-unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
-
-if(NOT HAVE_ONNXRUNTIME_CXX_API_H AND NOT HAVE_ONNXRUNTIME_ONNXRUNTIME_CXX_API_H)
-  message(
-    FATAL_ERROR
-    "onnxruntime_cxx_api.h is not reachable through onnxruntime::onnxruntime, neither as "
-    "<onnxruntime_cxx_api.h> nor as <onnxruntime/onnxruntime_cxx_api.h>."
-  )
-endif()
-
 ### Plugin main
-add_library(obs-backgroundremoval_options INTERFACE)
+add_library(${CMAKE_PROJECT_NAME}_options INTERFACE)
 
 if(MSVC)
-  target_compile_options(obs-backgroundremoval_options INTERFACE /W4 /WX)
+  target_compile_options(${CMAKE_PROJECT_NAME}_options INTERFACE /W4 /WX)
 elseif(APPLE OR OS_LINUX)
-  target_compile_definitions(obs-backgroundremoval_options INTERFACE SIMDE_ENABLE_OPENMP)
-  target_compile_options(obs-backgroundremoval_options INTERFACE -fopenmp-simd -Wall -Wextra -Werror)
+  target_compile_definitions(${CMAKE_PROJECT_NAME}_options INTERFACE SIMDE_ENABLE_OPENMP)
+  target_compile_options(${CMAKE_PROJECT_NAME}_options INTERFACE -fopenmp-simd -Wall -Wextra -Werror)
+endif()
+
+if(HAVE_ONNXRUNTIME_CUDA_EP)
+  message(STATUS "ONNX Runtime CUDA Execution Provider found")
+  target_compile_definitions(${CMAKE_PROJECT_NAME}_options INTERFACE HAVE_ONNXRUNTIME_CUDA_EP)
+endif()
+
+if(HAVE_ONNXRUNTIME_ROCM_EP)
+  message(STATUS "ONNX Runtime ROCM Execution Provider found")
+  target_compile_definitions(${CMAKE_PROJECT_NAME}_options INTERFACE HAVE_ONNXRUNTIME_ROCM_EP)
 endif()
 
 add_library(${CMAKE_PROJECT_NAME} MODULE)
-
-if(HAVE_ONNXRUNTIME_CXX_API_H)
-  target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE HAVE_ONNXRUNTIME_CXX_API_H)
-endif()
 
 add_subdirectory(src/update-checker/CurlClient)
 target_link_libraries(
   ${CMAKE_PROJECT_NAME}
   PRIVATE
-    obs-backgroundremoval_options
+    ${CMAKE_PROJECT_NAME}_options
     OBS::libobs
     OBS::obs-frontend-api
     onnxruntime::onnxruntime

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -5,10 +5,12 @@
 
 #include "background-filter.h"
 
-#ifdef HAVE_ONNXRUNTIME_CXX_API_H
+#if __has_include(<onnxruntime_cxx_api.h>)
 #include <onnxruntime_cxx_api.h>
-#else
+#elif __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
 #include <onnxruntime/onnxruntime_cxx_api.h>
+#else
+#error "onnxruntime_cxx_api.h was not found"
 #endif
 
 #ifdef _WIN32

--- a/src/background-filter.cpp
+++ b/src/background-filter.cpp
@@ -5,10 +5,10 @@
 
 #include "background-filter.h"
 
-#if __has_include(<onnxruntime_cxx_api.h>)
-#include <onnxruntime_cxx_api.h>
-#elif __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
+#if __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
 #include <onnxruntime/onnxruntime_cxx_api.h>
+#elif __has_include(<onnxruntime_cxx_api.h>)
+#include <onnxruntime_cxx_api.h>
 #else
 #error "onnxruntime_cxx_api.h was not found"
 #endif

--- a/src/enhance-filter.cpp
+++ b/src/enhance-filter.cpp
@@ -5,10 +5,12 @@
 
 #include "enhance-filter.h"
 
-#ifdef HAVE_ONNXRUNTIME_CXX_API_H
+#if __has_include(<onnxruntime_cxx_api.h>)
 #include <onnxruntime_cxx_api.h>
-#else
+#elif __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
 #include <onnxruntime/onnxruntime_cxx_api.h>
+#else
+#error "onnxruntime_cxx_api.h was not found"
 #endif
 
 #ifdef _WIN32

--- a/src/enhance-filter.cpp
+++ b/src/enhance-filter.cpp
@@ -5,10 +5,10 @@
 
 #include "enhance-filter.h"
 
-#if __has_include(<onnxruntime_cxx_api.h>)
-#include <onnxruntime_cxx_api.h>
-#elif __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
+#if __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
 #include <onnxruntime/onnxruntime_cxx_api.h>
+#elif __has_include(<onnxruntime_cxx_api.h>)
+#include <onnxruntime_cxx_api.h>
 #else
 #error "onnxruntime_cxx_api.h was not found"
 #endif

--- a/src/models/Model.hpp
+++ b/src/models/Model.hpp
@@ -6,10 +6,10 @@
 #ifndef MODEL_H
 #define MODEL_H
 
-#if __has_include(<onnxruntime_cxx_api.h>)
-#include <onnxruntime_cxx_api.h>
-#elif __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
+#if __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
 #include <onnxruntime/onnxruntime_cxx_api.h>
+#elif __has_include(<onnxruntime_cxx_api.h>)
+#include <onnxruntime_cxx_api.h>
 #else
 #error "onnxruntime_cxx_api.h was not found"
 #endif

--- a/src/models/Model.hpp
+++ b/src/models/Model.hpp
@@ -6,11 +6,14 @@
 #ifndef MODEL_H
 #define MODEL_H
 
-#ifdef HAVE_ONNXRUNTIME_CXX_API_H
+#if __has_include(<onnxruntime_cxx_api.h>)
 #include <onnxruntime_cxx_api.h>
-#else
+#elif __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
 #include <onnxruntime/onnxruntime_cxx_api.h>
+#else
+#error "onnxruntime_cxx_api.h was not found"
 #endif
+
 #include "../plugin-support.h"
 
 #ifdef _WIN32

--- a/src/ort-utils/ORTModelData.hpp
+++ b/src/ort-utils/ORTModelData.hpp
@@ -6,10 +6,10 @@
 #ifndef ORTMODELDATA_H
 #define ORTMODELDATA_H
 
-#if __has_include(<onnxruntime_cxx_api.h>)
-#include <onnxruntime_cxx_api.h>
-#elif __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
+#if __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
 #include <onnxruntime/onnxruntime_cxx_api.h>
+#elif __has_include(<onnxruntime_cxx_api.h>)
+#include <onnxruntime_cxx_api.h>
 #else
 #error "ONNX Runtime C++ headers were not found"
 #endif

--- a/src/ort-utils/ORTModelData.hpp
+++ b/src/ort-utils/ORTModelData.hpp
@@ -6,10 +6,12 @@
 #ifndef ORTMODELDATA_H
 #define ORTMODELDATA_H
 
-#ifdef HAVE_ONNXRUNTIME_CXX_API_H
+#if __has_include(<onnxruntime_cxx_api.h>)
 #include <onnxruntime_cxx_api.h>
-#else
+#elif __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
 #include <onnxruntime/onnxruntime_cxx_api.h>
+#else
+#error "ONNX Runtime C++ headers were not found"
 #endif
 
 struct ORTModelData {

--- a/src/ort-utils/ort-session-utils.cpp
+++ b/src/ort-utils/ort-session-utils.cpp
@@ -3,27 +3,45 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#if __has_include(<onnxruntime_cxx_api.h>)
-#include <onnxruntime_cxx_api.h>
-#elif __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
+#if __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
 #include <onnxruntime/onnxruntime_cxx_api.h>
+#elif __has_include(<onnxruntime_cxx_api.h>)
+#include <onnxruntime_cxx_api.h>
 #else
 #error "onnxruntime_cxx_api.h was not found"
 #endif
 
-#if __has_include(<cpu_provider_factory.h>)
-#include <cpu_provider_factory.h>
-#elif __has_include(<onnxruntime/cpu_provider_factory.h>)
+#if __has_include(<onnxruntime/cpu_provider_factory.h>)
 #include <onnxruntime/cpu_provider_factory.h>
-#else
-#error "cpu_provider_factory.h was not found"
+#elif __has_include(<cpu_provider_factory.h>)
+#include <cpu_provider_factory.h>
 #endif
 
+#ifdef HAVE_ONNXRUNTIME_CUDA_EP
+#if __has_include(<onnxruntime/cuda_provider_factory.h>)
+#include <onnxruntime/cuda_provider_factory.h>
+#elif __has_include(<cuda_provider_factory.h>)
+#include <cuda_provider_factory.h>
+#elif __has_include(<onnxruntime/core/providers/cuda/cuda_provider_factory.h>)
+#include <onnxruntime/core/providers/cuda/cuda_provider_factory.h>
+#endif
+#endif // HAVE_ONNXRUNTIME_CUDA_EP
+
+#ifdef HAVE_ONNXRUNTIME_ROCM_EP
+#if __has_include(<onnxruntime/rocm_provider_factory.h>)
+#include <onnxruntime/rocm_provider_factory.h>
+#elif __has_include(<rocm_provider_factory.h>)
+#include <rocm_provider_factory.h>
+#elif __has_include(<onnxruntime/core/providers/rocm/rocm_provider_factory.h>)
+#include <onnxruntime/core/providers/rocm/rocm_provider_factory.h>
+#endif
+#endif // HAVE_ONNXRUNTIME_ROCM_EP
+
 #if defined(__APPLE__)
-#if __has_include(<coreml_provider_factory.h>)
-#include <coreml_provider_factory.h>
-#elif __has_include(<onnxruntime/coreml_provider_factory.h>)
+#if __has_include(<onnxruntime/coreml_provider_factory.h>)
 #include <onnxruntime/coreml_provider_factory.h>
+#elif __has_include(<coreml_provider_factory.h>)
+#include <coreml_provider_factory.h>
 #else
 #error "coreml_provider_factory.h was not found"
 #endif

--- a/src/ort-utils/ort-session-utils.cpp
+++ b/src/ort-utils/ort-session-utils.cpp
@@ -3,22 +3,31 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#ifdef HAVE_ONNXRUNTIME_CXX_API_H
+#if __has_include(<onnxruntime_cxx_api.h>)
 #include <onnxruntime_cxx_api.h>
-#include <cpu_provider_factory.h>
-#else
+#elif __has_include(<onnxruntime/onnxruntime_cxx_api.h>)
 #include <onnxruntime/onnxruntime_cxx_api.h>
-#include <onnxruntime/cpu_provider_factory.h>
+#else
+#error "onnxruntime_cxx_api.h was not found"
 #endif
-#include <filesystem>
+
+#if __has_include(<cpu_provider_factory.h>)
+#include <cpu_provider_factory.h>
+#elif __has_include(<onnxruntime/cpu_provider_factory.h>)
+#include <onnxruntime/cpu_provider_factory.h>
+#else
+#error "cpu_provider_factory.h was not found"
+#endif
 
 #if defined(__APPLE__)
-#ifdef HAVE_ONNXRUNTIME_CXX_API_H
+#if __has_include(<coreml_provider_factory.h>)
 #include <coreml_provider_factory.h>
-#else
+#elif __has_include(<onnxruntime/coreml_provider_factory.h>)
 #include <onnxruntime/coreml_provider_factory.h>
+#else
+#error "coreml_provider_factory.h was not found"
 #endif
-#endif
+#endif // __APPLE__
 
 #ifdef _WIN32
 #include <wchar.h>


### PR DESCRIPTION
## Check

Building with CUDA or ROCM works with Docker's Arch Linux.

## Overview

This pull request improves the detection and integration of ONNX Runtime headers and execution providers, making the build system more robust and portable. The main changes include replacing custom header checks with standardized `__has_include` logic, enhancing CMake checks for CUDA and ROCM execution providers, and refactoring how compile options and definitions are set for the project.

**Build system improvements:**

* Replaced custom preprocessor checks for ONNX Runtime C++ headers (`HAVE_ONNXRUNTIME_CXX_API_H`) with standardized `__has_include` checks throughout the codebase, improving portability and simplifying header detection. [[1]](diffhunk://#diff-4e873e25a59f1bf23600cc652a834a24cb84ecf53e865840736f921b5f7a0160L8-R13) [[2]](diffhunk://#diff-0ee3ce290428e54453d2f83833c9dcefb8d7ee2e6995fdc230ab9edc1738ffceL8-R13) [[3]](diffhunk://#diff-01cae612d7ef497725d336036d5c01262f9810d70919234240a92e3bb050c23dL9-R16) [[4]](diffhunk://#diff-874c66073224806abde5d42561bec4a819a4ff58070326f04a264f5b6f154ad5L9-R14) [[5]](diffhunk://#diff-d0c48b206b8829721249ab31b8dcf7d8dcd3626696c949e7e33c41ebdbeb7a41L6-R30)
* Enhanced the CMake configuration in `CMakeLists.txt` to automatically detect the availability of CUDA and ROCM execution providers for ONNX Runtime using a new function, and to propagate these results as compile definitions. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL153-R155) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL177-R253)
* Added CMake modules `CheckCXXSymbolExists` and `CMakePushCheckState` to support improved feature detection.

**Code refactoring:**

* Updated the logic for including provider factory headers (such as `cpu_provider_factory.h` and `coreml_provider_factory.h`) to use `__has_include`, ensuring the correct headers are included regardless of their location.
* Refactored the creation and usage of the options interface library in CMake to use a project-wide variable, consolidating compile options and definitions.

These changes make the project more robust to different ONNX Runtime installations and improve maintainability.

## Pull Request Checklist

Please read our latest [CONTRIBUTING.md](https://github.com/royshil/obs-backgroundremoval/blob/main/CONTRIBUTING.md).

- [x] I have read the latest CONTRIBUTING.md.
- [x] I have acknowledged the licensing and patent grant policy.
- [x] I have included the required license headers.
- [x] I am confident with my code integrity.
- [x] I have signed off and verified all my commits.
