### PR TITLE
Assert the depth instead of the full model dtype

### DIFF
--- a/src/models/Model.hpp
+++ b/src/models/Model.hpp
@@ -64,7 +64,7 @@ static void chw_to_hwc_32f(cv::InputArray src, cv::OutputArray dst)
 	const int height = srcMat.rows;
 	const int width = srcMat.cols;
 	const int dtype = srcMat.type();
-	assert(dtype == CV_32F);
+	assert(CV_MAT_DEPTH(dtype) == CV_32F);
 	const int channelStride = height * width;
 
 	// Flatten to a vector of channels


### PR DESCRIPTION
This fixes an assert crash if you have e.g. SINet selected as the model.

## Problem description

`cv::Mat::type()` contains the bit depth of each channel and the number of channels encoded within a single value. Possible values of `cv::Mat::type()` are `CV_32FC1`, `CV_32FC2`, and so on.
This assertion requires `srcMat` stored in Float32, and is not intended to restrict the number of channels.
`CV_MAT_DEPTH(dtype)` extracts only the number format and this will fix the root cause of crashes.
Note that the RelWithDebInfo configuration might disable any `assert()` macros and this is possibly why this bug is left untouched until now.

## Pull Request Checklist

Please read our latest [CONTRIBUTING.md](https://github.com/royshil/obs-backgroundremoval/blob/main/CONTRIBUTING.md).

- [x] I have read the latest CONTRIBUTING.md.
- [x] I have acknowledged the licensing and patent grant policy.
- [x] I have included the required license headers.
- [x] I am confident with my code integrity.
- [x] I have signed off and verified all my commits.
