### PR TITLE
Fix release process

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -505,7 +505,7 @@ jobs:
         if: inputs.attest-artifacts && inputs.notarize
         shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
         env:
-          CODESIGN_TEAM: ${{ steps.setup-codesign.outputs.CODESIGN_TEAM }}
+          CODESIGN_TEAM: ${{ vars.CODESIGN_TEAM }}
           MACOS_NOTARIZATION_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
           MACOS_NOTARIZATION_USERNAME: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
           PKG_ARTIFACT_NAME: ${{ steps.expected-artifacts.outputs.PKG_ARTIFACT_NAME }}
@@ -513,7 +513,7 @@ jobs:
           xcrun notarytool submit "${PKG_ARTIFACT_NAME:?}" \
             --apple-id "${MACOS_NOTARIZATION_USERNAME:?}" \
             --password "${MACOS_NOTARIZATION_PASSWORD:?}" \
-            --team-id "${CODESIGN_TEAM:?}" \
+            --team-id "${CODESIGN_TEAM:?vars.CODESIGN_TEAM is not set}" \
             --wait
           xcrun stapler staple "${PKG_ARTIFACT_NAME:?}"
           xcrun stapler validate "${PKG_ARTIFACT_NAME:?}"

--- a/tests/Scenarios/2000_windows-about-dialog.test.ps1
+++ b/tests/Scenarios/2000_windows-about-dialog.test.ps1
@@ -182,30 +182,46 @@ function Write-UpdateConfig {
         [Text.UTF8Encoding]::new($false))
 }
 
-function Read-UpdateConfig {
+function Wait-ForUpdateConfig {
+    param(
+        [Parameter(Mandatory)][scriptblock] $ConditionScript,
+        [Parameter(Mandatory)][string] $Description,
+        [int] $TimeoutSeconds = 3
+    )
+    $lastContents = $null
+    $lastError = $null
     $stopwatch = [Diagnostics.Stopwatch]::StartNew()
-    while ($stopwatch.Elapsed.TotalSeconds -lt 3) {
-        if (Test-Path -LiteralPath $UpdateConfig -PathType Leaf) {
-            try { return Get-Content -LiteralPath $UpdateConfig -Raw } catch [IO.IOException] {}
+    while ($stopwatch.Elapsed.TotalSeconds -lt $TimeoutSeconds) {
+        try {
+            $lastContents = Get-Content -LiteralPath $UpdateConfig -Raw -ErrorAction Stop
+            $lastError = $null
+            if (& $ConditionScript $lastContents) { return $lastContents }
+        } catch [System.Management.Automation.ItemNotFoundException], [IO.IOException] {
+            $lastError = $_.Exception.Message
         }
         Start-Sleep -Milliseconds 50
     }
-    throw 'Plugin update.ini was not written or remained locked.'
+    if ($lastError) {
+        throw "Timed out waiting for update.ini to $Description. Last read error: $lastError"
+    }
+    throw "Timed out waiting for update.ini to $Description. Last contents: $lastContents"
 }
 
 function Assert-VersionAcknowledged {
     param([string] $Expected = $Version)
-    if ((Read-UpdateConfig) -notmatch "(?m)^version=$([regex]::Escape($Expected))`r?$") {
-        throw "update.ini does not contain version=$Expected."
-    }
+    Wait-ForUpdateConfig -Description "contain version=$Expected" -ConditionScript {
+        param($contents)
+        $contents -match "(?m)^version=$([regex]::Escape($Expected))`r?$"
+    } | Out-Null
 }
 
 function Assert-Notifications {
     param([bool] $Enabled)
     $expected = if ($Enabled) { 'true' } else { 'false' }
-    if ((Read-UpdateConfig) -notmatch "(?m)^check_for_updates=$expected`r?$") {
-        throw "update.ini does not contain check_for_updates=$expected."
-    }
+    Wait-ForUpdateConfig -Description "contain check_for_updates=$expected" -ConditionScript {
+        param($contents)
+        $contents -match "(?m)^check_for_updates=$expected`r?$"
+    } | Out-Null
 }
 
 function Get-AboutDialog {
@@ -394,7 +410,10 @@ $cases['ST-2000.9 current version cannot be recorded'] = {
             Assert-Log $log '[obs-backgroundremoval] Failed to save update config'
         }
     } finally { Set-ItemProperty -LiteralPath $UpdateConfig -Name IsReadOnly -Value $false }
-    if ((Read-UpdateConfig) -notmatch '(?m)^version=0\.0\.0\r?$') { throw 'The earlier version was changed.' }
+    Wait-ForUpdateConfig -Description 'retain version=0.0.0' -ConditionScript {
+        param($contents)
+        $contents -match '(?m)^version=0\.0\.0\r?$'
+    } | Out-Null
 }
 $cases['ST-2000.10 unwritable stale temporary file'] = {
     Write-UpdateConfig '[update]' 'version=0.0.0' 'check_for_updates=false'


### PR DESCRIPTION
Fixes flaky tests on Windows and add vars.CODESIGN_TEAM to fix the Release CD

## Overview

This pull request refactors the way update configuration file checks are performed in the Windows about dialog tests. It introduces a new `Wait-ForUpdateConfig` function to reliably wait for expected file contents, replacing the previous immediate-read approach. This makes the tests more robust against timing issues and file access errors.

**Test reliability improvements:**

* Added a new `Wait-ForUpdateConfig` function that waits for the `update.ini` file to meet a specified condition, with timeout and improved error reporting. This replaces the previous `Read-UpdateConfig` function.
* Updated `Assert-VersionAcknowledged`, `Assert-Notifications`, and test cases to use `Wait-ForUpdateConfig` for checking file contents, improving reliability and clarity of test failures. [[1]](diffhunk://#diff-198346054bba6fec354e86c10273450a6447447c1389e847fb7a7437da8e72d5L185-R224) [[2]](diffhunk://#diff-198346054bba6fec354e86c10273450a6447447c1389e847fb7a7437da8e72d5L397-R416)

**Workflow environment variable change:**

* In `.github/workflows/build-macos.yml`, changed the way `CODESIGN_TEAM` is sourced, now using `${{ vars.CODESIGN_TEAM }}` instead of the output from a previous step, and improved error messaging if the variable is not set.

## Pull Request Checklist

Please read our latest [CONTRIBUTING.md](https://github.com/royshil/obs-backgroundremoval/blob/main/CONTRIBUTING.md).

- [x] I have read the latest CONTRIBUTING.md.
- [x] I have acknowledged the licensing and patent grant policy.
- [x] I have included the required license headers.
- [x] I am confident with my code integrity.
- [x] I have signed off and verified all my commits.
