### PR TITLE
Add review gates for PR and release

### DIFF
--- a/.github/workflows/build-arch.yml
+++ b/.github/workflows/build-arch.yml
@@ -14,12 +14,18 @@ on:
         required: false
         type: string
         default: archlinux:base-devel
+      release-build:
+        description: Builds a release.
+        required: true
+        type: boolean
 
 jobs:
   build:
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     container: ${{ inputs.image }}
+
+    environment: ${{ inputs.release-build && 'release-linux' || null }}
 
     steps:
       - name: Prepare runner image (Arch)

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -17,6 +17,10 @@ on:
         description: Builds for arm64.
         required: true
         type: boolean
+      release-build:
+        description: Builds a release.
+        required: true
+        type: boolean
       PACKAGE_VERSION_SUFFIX_FORKY:
         description: Version suffix for forky.
         required: false
@@ -38,6 +42,8 @@ jobs:
     runs-on: ${{ inputs.arm64 && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     timeout-minutes: 180
     container: debian:forky-20260803
+
+    environment: ${{ inputs.release-build && 'release-linux' || null }}
 
     outputs:
       DEB_ARTIFACT_NAME: ${{ steps.package.outputs.DEB_ARTIFACT_NAME }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -13,8 +13,8 @@ on:
         description: Attests artifacts.
         required: true
         type: boolean
-      notarize:
-        description: Notarizes pkg.
+      release-build:
+        description: Builds and notarizes a release.
         required: true
         type: boolean
       x86_64:
@@ -59,6 +59,8 @@ jobs:
   tahoe:
     runs-on: macos-26
     timeout-minutes: 180
+
+    environment: ${{ inputs.release-build && 'release-macos' || null }}
 
     outputs:
       DSYM_ARTIFACT_NAME: ${{ steps.archive-dsym.outputs.DSYM_ARTIFACT_NAME }}
@@ -274,7 +276,7 @@ jobs:
 
       - name: Set up Apple code signing
         id: setup-codesign
-        if: inputs.attest-artifacts
+        if: inputs.release-build
         uses: kaito-tokyo/setup-apple-codesigning@b9f7d7c6819fe6f6bb44694b75963918dcbddd27 # v1.0.0
         with:
           MACOS_SIGNING_CERT: ${{ secrets.MACOS_SIGNING_CERT }}
@@ -282,7 +284,7 @@ jobs:
 
       - name: Package signed PKG (macOS)
         id: package-signed
-        if: inputs.attest-artifacts
+        if: inputs.release-build
         shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
         env:
           ARCH: ${{ inputs.x86_64 && 'x86_64' || 'arm64' }}
@@ -322,14 +324,8 @@ jobs:
 
           printf 'PKG_ARTIFACT_NAME=%s\n' "${PKG_ARTIFACT_NAME:?}" | tee -a "${GITHUB_OUTPUT:?}"
 
-      - name: Attest signed PKG (macOS)
-        if: inputs.attest-artifacts && !inputs.notarize
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-path: ${{ steps.package-signed.outputs.PKG_ARTIFACT_NAME }}
-
       - name: Notarize signed PKG
-        if: inputs.attest-artifacts && inputs.notarize
+        if: inputs.release-build
         shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
         env:
           CODESIGN_TEAM: ${{ vars.CODESIGN_TEAM }}
@@ -347,14 +343,14 @@ jobs:
           spctl --assess --type install --verbose=2 "${PKG_ARTIFACT_NAME:?}"
 
       - name: Attest notarized PKG (macOS)
-        if: inputs.attest-artifacts && inputs.notarize
+        if: inputs.attest-artifacts && inputs.release-build
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: ${{ steps.package-signed.outputs.PKG_ARTIFACT_NAME }}
 
       - name: Package unsigned PKG (macOS)
         id: package-unsigned
-        if: ${{ !inputs.attest-artifacts }}
+        if: ${{ !inputs.release-build }}
         shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
         env:
           ARCH: ${{ inputs.x86_64 && 'x86_64' || 'arm64' }}
@@ -388,6 +384,12 @@ jobs:
             "${PKG_ARTIFACT_NAME:?}"
 
           printf 'PKG_ARTIFACT_NAME=%s\n' "${PKG_ARTIFACT_NAME:?}" | tee -a "${GITHUB_OUTPUT:?}"
+
+      - name: Attest unsigned PKG (macOS)
+        if: inputs.attest-artifacts && !inputs.release-build
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: ${{ steps.package-unsigned.outputs.PKG_ARTIFACT_NAME }}
 
       - name: Upload PKG artifact (macOS)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -17,6 +17,10 @@ on:
         description: Builds for arm64.
         required: true
         type: boolean
+      release-build:
+        description: Builds a release.
+        required: true
+        type: boolean
       PACKAGE_VERSION_SUFFIX_RESOLUTE:
         description: Version suffix for resolute.
         required: false
@@ -37,6 +41,8 @@ jobs:
   resolute:
     runs-on: ${{ inputs.arm64 && 'ubuntu-26.04-arm' || 'ubuntu-26.04' }}
     timeout-minutes: 180
+
+    environment: ${{ inputs.release-build && 'release-linux' || null }}
 
     outputs:
       DEB_ARTIFACT_NAME: ${{ steps.artifact-names.outputs.DEB_ARTIFACT_NAME }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,6 +13,10 @@ on:
         description: Attests artifacts.
         required: true
         type: boolean
+      release-build:
+        description: Builds a release.
+        required: true
+        type: boolean
       runs-on:
         description: GitHub Actions runner label.
         required: true
@@ -33,6 +37,8 @@ jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 180
+
+    environment: ${{ inputs.release-build && 'release-windows' || null }}
 
     outputs:
       ZIP_ARTIFACT_NAME: ${{ steps.package-zip.outputs.ZIP_ARTIFACT_NAME }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,7 +79,7 @@ jobs:
         shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
         run: bin/check reuse
 
-  accept-check:
+  accept-check-ci:
     if: always()
     needs:
       - check-clang-format
@@ -90,9 +90,7 @@ jobs:
     permissions: {}
     steps:
       - name: Check workflow results
+        env:
+          NEEDS: ${{ toJSON(needs) }}
         shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
-        run: |
-          [[ '${{ needs.check-clang-format.result }}' == 'success' ]] &&
-          [[ '${{ needs.check-gersemi.result }}' == 'success' ]] &&
-          [[ '${{ needs.check-reuse.result }}' == 'success' ]] &&
-          printf 'OK\n'
+        run: jq -e 'all(.[]; .result == "success")' <<< "${NEEDS:?}"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,6 +22,7 @@ jobs:
       contents: read
     with:
       attest-artifacts: false
+      release-build: false
       runs-on: windows-2025-vs2026
 
   build-macos-arm64:
@@ -30,7 +31,7 @@ jobs:
       contents: read
     with:
       attest-artifacts: false
-      notarize: false
+      release-build: false
       x86_64: false
       TAHOE_DEVELOPER_DIR: /Applications/Xcode_26.5.app
 
@@ -40,7 +41,7 @@ jobs:
       contents: read
     with:
       attest-artifacts: false
-      notarize: false
+      release-build: false
       x86_64: true
       TAHOE_DEVELOPER_DIR: /Applications/Xcode_26.5.app
 
@@ -51,6 +52,7 @@ jobs:
     with:
       attest-artifacts: false
       arm64: false
+      release-build: false
 
   build-debian-arm64:
     uses: ./.github/workflows/build-debian.yml
@@ -59,6 +61,7 @@ jobs:
     with:
       attest-artifacts: false
       arm64: true
+      release-build: false
 
   build-ubuntu-amd64:
     uses: ./.github/workflows/build-ubuntu.yml
@@ -67,6 +70,7 @@ jobs:
     with:
       attest-artifacts: false
       arm64: false
+      release-build: false
 
   build-ubuntu-arm64:
     uses: ./.github/workflows/build-ubuntu.yml
@@ -75,8 +79,32 @@ jobs:
     with:
       attest-artifacts: false
       arm64: true
+      release-build: false
 
   build-arch:
     uses: ./.github/workflows/build-arch.yml
     permissions:
       contents: read
+    with:
+      release-build: false
+
+  accept-pr-check:
+    if: always()
+    needs:
+      - build-arch
+      - build-debian-amd64
+      - build-debian-arm64
+      - build-macos-arm64
+      - build-macos-x86_64
+      - build-ubuntu-amd64
+      - build-ubuntu-arm64
+      - build-windows-x64
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - name: Check workflow results
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        shell: bash --noprofile --norc -euo pipefail -O nullglob {0}
+        run: jq -e 'all(.[]; .result == "success")' <<< "${NEEDS:?}"

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -58,6 +58,7 @@ jobs:
       id-token: write
     with:
       attest-artifacts: true
+      release-build: ${{ inputs.release-build || false }}
       runs-on: windows-2025-vs2026
 
   build-macos-arm64:
@@ -70,7 +71,7 @@ jobs:
       id-token: write
     with:
       attest-artifacts: true
-      notarize: ${{ inputs.release-build || false }}
+      release-build: ${{ inputs.release-build || false }}
       x86_64: false
       TAHOE_DEVELOPER_DIR: /Applications/Xcode_26.5.app
 
@@ -84,7 +85,7 @@ jobs:
       id-token: write
     with:
       attest-artifacts: true
-      notarize: ${{ inputs.release-build || false }}
+      release-build: ${{ inputs.release-build || false }}
       x86_64: true
       TAHOE_DEVELOPER_DIR: /Applications/Xcode_26.5.app
 
@@ -98,6 +99,7 @@ jobs:
     with:
       attest-artifacts: true
       arm64: false
+      release-build: ${{ inputs.release-build || false }}
 
   build-debian-arm64:
     uses: ./.github/workflows/build-debian.yml
@@ -109,6 +111,7 @@ jobs:
     with:
       attest-artifacts: true
       arm64: true
+      release-build: ${{ inputs.release-build || false }}
 
   build-ubuntu-amd64:
     uses: ./.github/workflows/build-ubuntu.yml
@@ -120,6 +123,7 @@ jobs:
     with:
       attest-artifacts: true
       arm64: false
+      release-build: ${{ inputs.release-build || false }}
 
   build-ubuntu-arm64:
     uses: ./.github/workflows/build-ubuntu.yml
@@ -131,8 +135,11 @@ jobs:
     with:
       attest-artifacts: true
       arm64: true
+      release-build: ${{ inputs.release-build || false }}
 
   build-arch:
     uses: ./.github/workflows/build-arch.yml
     permissions:
       contents: read
+    with:
+      release-build: ${{ inputs.release-build || false }}


### PR DESCRIPTION
I want to add rulesets for signed commits and status check gates in addition to required self-review gate for releasing. This PR is preparation.

## Overview

This pull request updates the build workflows for all supported platforms to introduce a unified `release-build` input, which controls whether a job performs a release build (with code signing, notarization, and artifact attestation) or a regular build. It also standardizes environment selection for release builds and simplifies conditional logic in the workflows. Additionally, the PR improves how workflow results are checked and reported.

**Workflow input and logic standardization:**

* Added a `release-build` boolean input to all build workflows (`build-macos.yml`, `build-windows.yml`, `build-ubuntu.yml`, `build-debian.yml`, `build-arch.yml`) to consistently control release-specific steps such as code signing and notarization. [[1]](diffhunk://#diff-a1654f4357833dfc4d0c6a8d39c2e3ee30ceea604c29238846903993434ab384L16-R17) [[2]](diffhunk://#diff-01d393d5fc96ff0e19c736f6b445df76a62887b81071928a950e936379746f2dR16-R19) [[3]](diffhunk://#diff-3dc91c5652448e68371fa6d23e2a83da91a66ad49d85a828dcaf8bcab84ded5fR20-R23) [[4]](diffhunk://#diff-b0fba99d624c988eddcb2d2fb3306fd0e82f099ce7e74989123f2a348ab7b34bR20-R23) [[5]](diffhunk://#diff-7902169edd1fc476762e6dea51cda32ab8b7cf90bce81019cc1ee1c00978f9edR17-R29)
* Updated jobs to set the appropriate deployment environment (e.g., `release-macos`, `release-linux`, `release-windows`) only when `release-build` is true, ensuring release steps are isolated. [[1]](diffhunk://#diff-a1654f4357833dfc4d0c6a8d39c2e3ee30ceea604c29238846903993434ab384R63-R64) [[2]](diffhunk://#diff-01d393d5fc96ff0e19c736f6b445df76a62887b81071928a950e936379746f2dR41-R42) [[3]](diffhunk://#diff-3dc91c5652448e68371fa6d23e2a83da91a66ad49d85a828dcaf8bcab84ded5fR45-R46) [[4]](diffhunk://#diff-b0fba99d624c988eddcb2d2fb3306fd0e82f099ce7e74989123f2a348ab7b34bR46-R47) [[5]](diffhunk://#diff-7902169edd1fc476762e6dea51cda32ab8b7cf90bce81019cc1ee1c00978f9edR17-R29)

**macOS workflow improvements:**

* Replaced the separate `notarize` input with the unified `release-build` input, and updated all relevant steps (code signing, notarization, artifact attestation, and packaging) to use this input for conditional execution. Added explicit attestation for unsigned PKG artifacts when not a release build. [[1]](diffhunk://#diff-a1654f4357833dfc4d0c6a8d39c2e3ee30ceea604c29238846903993434ab384L277-R287) [[2]](diffhunk://#diff-a1654f4357833dfc4d0c6a8d39c2e3ee30ceea604c29238846903993434ab384L325-R328) [[3]](diffhunk://#diff-a1654f4357833dfc4d0c6a8d39c2e3ee30ceea604c29238846903993434ab384L350-R353) [[4]](diffhunk://#diff-a1654f4357833dfc4d0c6a8d39c2e3ee30ceea604c29238846903993434ab384R388-R393)

**Workflow result checking:**

* Refactored the result-checking jobs in `check.yml` and added a new `accept-pr-check` job in `pr-check.yml` to use a more robust and scalable approach with `jq` for verifying that all dependent jobs succeeded, instead of hardcoding each job’s result. [[1]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L82-R82) [[2]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428R93-R96) [[3]](diffhunk://#diff-e76e5134b85a9eb3e0d9ce8e671ce97c8c577ff3c24162c45d71691078201347R82-R110)

**Propagation of `release-build` input:**

* Ensured that the `release-build` input is properly passed through all jobs in `pr-check.yml` and `push-main.yml`, so that the correct build type is triggered in downstream workflows. [[1]](diffhunk://#diff-e76e5134b85a9eb3e0d9ce8e671ce97c8c577ff3c24162c45d71691078201347R25) [[2]](diffhunk://#diff-e76e5134b85a9eb3e0d9ce8e671ce97c8c577ff3c24162c45d71691078201347L33-R34) [[3]](diffhunk://#diff-e76e5134b85a9eb3e0d9ce8e671ce97c8c577ff3c24162c45d71691078201347L43-R44) [[4]](diffhunk://#diff-e76e5134b85a9eb3e0d9ce8e671ce97c8c577ff3c24162c45d71691078201347R55) [[5]](diffhunk://#diff-e76e5134b85a9eb3e0d9ce8e671ce97c8c577ff3c24162c45d71691078201347R64) [[6]](diffhunk://#diff-e76e5134b85a9eb3e0d9ce8e671ce97c8c577ff3c24162c45d71691078201347R73) [[7]](diffhunk://#diff-e76e5134b85a9eb3e0d9ce8e671ce97c8c577ff3c24162c45d71691078201347R82-R110) [[8]](diffhunk://#diff-2784b9c374ced1e3330a88b99fc29d7a5981296ecf89649161a9aaaf4ea5b25eR61) [[9]](diffhunk://#diff-2784b9c374ced1e3330a88b99fc29d7a5981296ecf89649161a9aaaf4ea5b25eL73-R74) [[10]](diffhunk://#diff-2784b9c374ced1e3330a88b99fc29d7a5981296ecf89649161a9aaaf4ea5b25eL87-R88) [[11]](diffhunk://#diff-2784b9c374ced1e3330a88b99fc29d7a5981296ecf89649161a9aaaf4ea5b25eR102) [[12]](diffhunk://#diff-2784b9c374ced1e3330a88b99fc29d7a5981296ecf89649161a9aaaf4ea5b25eR114) [[13]](diffhunk://#diff-2784b9c374ced1e3330a88b99fc29d7a5981296ecf89649161a9aaaf4ea5b25eR126) [[14]](diffhunk://#diff-2784b9c374ced1e3330a88b99fc29d7a5981296ecf89649161a9aaaf4ea5b25eR138-R145)

These changes make the build and release process more maintainable, consistent, and easier to extend for future requirements.

## Pull Request Checklist

Please read our latest [CONTRIBUTING.md](https://github.com/royshil/obs-backgroundremoval/blob/main/CONTRIBUTING.md).

- [x] I have read the latest CONTRIBUTING.md.
- [x] I have acknowledged the licensing and patent grant policy.
- [x] I have included the required license headers.
- [x] I am confident with my code integrity.
- [x] I have signed off and verified all my commits.
